### PR TITLE
fix: スライダーのサムと選択範囲の色の調整

### DIFF
--- a/src/components/search/ProductSearch.tsx
+++ b/src/components/search/ProductSearch.tsx
@@ -648,7 +648,9 @@ export default function ProductSearch() {
                       step={isHighPriceFilterEnabled ? 1000 : 100} // 高額商品フィルタリング時はステップを大きく
                       value={priceRange}
                       onValueChange={(value) => setPriceRange([value[0], value[1]])}
-                      className={`w-full ${isHighPriceFilterEnabled ? '[&>span:first-child]:bg-blue-500' : ''}`} // スライダーの色を動的に変更
+                      className="w-full" // スライダーの全体的な幅を制御
+                      rangeClassName={isHighPriceFilterEnabled ? 'bg-blue-500' : ''} // レンジの色を動的に変更
+                      thumbClassName={isHighPriceFilterEnabled ? 'border-blue-700' : ''} // サムの輪郭色のみを動的に変更
                     />
                     <div className="flex justify-between text-xs mt-2">
                       <span>{priceRange[0]}円</span>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -11,8 +11,13 @@ function Slider({
   value,
   min = 0,
   max = 100,
+  rangeClassName,
+  thumbClassName,
   ...props
-}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+}: React.ComponentProps<typeof SliderPrimitive.Root> & {
+  rangeClassName?: string;
+  thumbClassName?: string;
+}) {
   const _values = React.useMemo(
     () =>
       Array.isArray(value)
@@ -45,7 +50,8 @@ function Slider({
         <SliderPrimitive.Range
           data-slot="slider-range"
           className={cn(
-            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full",
+            rangeClassName
           )}
         />
       </SliderPrimitive.Track>
@@ -53,7 +59,10 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className={cn(
+            "border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50",
+            thumbClassName
+          )}
         />
       ))}
     </SliderPrimitive.Root>


### PR DESCRIPTION
高額商品フィルタリングが有効な際に、スライダーのトラックはデフォルト色、選択範囲はblue-500、サムの背景色はデフォルト色、輪郭色はblue-700になるように調整しました。
close #62 