### PR TITLE
fix: マイナス検索用プレフィックス入力後のタグ候補をクリックすると、通常検索対象としてクエリに加えられる問題を修正

### DIFF
--- a/src/components/search/ProductSearch.tsx
+++ b/src/components/search/ProductSearch.tsx
@@ -497,7 +497,7 @@ export default function ProductSearch() {
               {tagSuggestions.map(tag => (
                 <li
                   key={tag}
-                  onClick={() => handleAddTag(tag)} // サジェストからの追加時はプレフィックスなし
+                  onClick={() => handleAddTag(searchQuery.startsWith('-') ? `-${tag}` : tag)} // マイナス検索のプレフィックスを考慮してタグを追加
                   className="px-3 py-2 text-sm cursor-pointer hover:bg-gray-100"
                 >
                   {tag}


### PR DESCRIPTION
issue #83で報告された、マイナス検索用プレフィックス入力後のタグ候補をクリックすると、通常検索対象としてクエリに加えられる問題を修正しました。
`src/components/search/ProductSearch.tsx` のタグ候補クリック時のロジックを修正し、現在の検索クエリがマイナス検索のプレフィックスを含んでいる場合に、マイナス検索タグとして追加されるようにしました。

close #81
close #83