### PR TITLE
fix: ダークモードにおけるヘッダーと検索バーの背景色、およびロゴの表示を修正

### DIFF
--- a/public/pslogo-white.svg
+++ b/public/pslogo-white.svg
@@ -1,0 +1,21 @@
+<svg width="500" height="500" viewBox="64.5 19.5 71 65.5" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- 背景を透明にするため、<rect>を削除 -->
+
+  <!-- タグクラウドをイメージした円と線のデザイン -->
+  <g fill="none" stroke="#FFFFFF" stroke-width="1">
+    <circle cx="100" cy="50" r="30"/>
+    <circle cx="80" cy="30" r="5"/>
+    <circle cx="120" cy="30" r="5"/>
+    <circle cx="70" cy="60" r="5"/>
+    <circle cx="130" cy="60" r="5"/>
+    <circle cx="90" cy="80" r="5"/>
+    <circle cx="110" cy="80" r="5"/>
+    <path d="M 80 30 Q 100 50 120 30"/>
+    <path d="M 70 60 Q 100 50 130 60"/>
+    <path d="M 90 80 Q 100 50 110 80"/>
+  </g>
+
+  <!-- テキスト "PolySeek" -->
+  <text x="50" y="50" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="#FFFFFF"></text>
+</svg>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { useState, useEffect, useRef, useCallback, Suspense } from 'react';
 import { useSession, signIn, signOut } from "next-auth/react";
 import { useRouter } from 'next/navigation';
+import { useTheme } from 'next-themes';
 import {
   Dialog,
   DialogContent,
@@ -23,6 +24,8 @@ import ProductSearch from '@/components/search/ProductSearch'; // Import Product
 export default function Header() {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const { theme, systemTheme } = useTheme(); // Add useTheme hook
+  const [mounted, setMounted] = useState(false); // Add mounted state
   const [isHeaderVisible, setIsHeaderVisible] = useState(true);
   const [prevScrollPos, setPrevScrollPos] = useState(0);
   const [isRegisterModalOpen, setIsRegisterModalOpen] = useState(false);
@@ -47,6 +50,7 @@ export default function Header() {
     }, [prevScrollPos]);
 
   useEffect(() => {
+    setMounted(true); // Set mounted to true after component mounts
     window.addEventListener('scroll', handleScroll);
 
     return () => {
@@ -54,17 +58,21 @@ export default function Header() {
     };
   }, [handleScroll]);
 
+  if (!mounted) { // Render nothing until mounted to prevent hydration mismatch
+    return null;
+  }
+
   return (
     // Apply bg-white to the outer header to ensure ProductSearch background blends correctly
     <header
       ref={headerRef}
-      className={`fixed top-0 left-0 w-full bg-white z-50 transition-transform duration-300 ease-in-out ${ // Added z-index and ease
+      className={`fixed top-0 left-0 w-full bg-white dark:bg-gray-900 z-50 transition-transform duration-300 ease-in-out ${ // Added z-index and ease
         isHeaderVisible ? 'translate-y-0' : '-translate-y-full' // Use -translate-y-full for clarity
       }`}
       style={{ boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)' }} // Apply shadow here if needed consistently
     >
       {/* Top Navigation Bar */}
-      <div className="container mx-auto py-3 px-4 md:px-6 flex items-center justify-between border-b border-gray-200"> {/* Reduced padding slightly, added border */}
+      <div className="container mx-auto py-3 px-4 md:px-6 flex items-center justify-between border-b border-gray-200 dark:border-gray-700"> {/* Reduced padding slightly, added border */}
         {/* Mobile Navigation (Visible on small screens) */}
         {/* Mobile Navigation (Visible on small screens) */}
         <div className="md:hidden flex items-center justify-between w-full">
@@ -77,7 +85,7 @@ export default function Header() {
                 <Button variant="ghost" size="sm">プロフィール</Button>
               </Link>
               <Link href="/" className="flex items-center">
-                <Image src="/pslogo.svg" alt="PolySeek Logo" width={24} height={24} className="h-6 w-auto" />
+                <Image src={(theme === 'dark' || (theme === 'system' && systemTheme === 'dark')) ? "/pslogo-white.svg" : "/pslogo.svg"} alt="PolySeek Logo" width={24} height={24} className="h-6 w-auto" />
               </Link>
               <Button variant="ghost" size="sm" onClick={() => signOut()}>ログアウト</Button>
             </>
@@ -101,7 +109,7 @@ export default function Header() {
                 </DialogContent>
               </Dialog>
               <Link href="/" className="flex items-center">
-                <Image src="/pslogo.svg" alt="PolySeek Logo" width={24} height={24} className="h-6 w-auto" />
+                <Image src={(theme === 'dark' || (theme === 'system' && systemTheme === 'dark')) ? "/pslogo-white.svg" : "/pslogo.svg"} alt="PolySeek Logo" width={24} height={24} className="h-6 w-auto" />
               </Link>
               <Button variant="ghost" size="sm" onClick={() => signIn('google')}>Googleログイン</Button>
               <Button variant="ghost" size="sm" onClick={() => signIn('discord')}>Discordログイン</Button>
@@ -111,8 +119,8 @@ export default function Header() {
 
         {/* Desktop Navigation (Hidden on small screens) */}
         <Link href="/" className="hidden md:flex items-center space-x-2">
-          <Image src="/pslogo.svg" alt="PolySeek Logo" width={24} height={24} className="h-6 w-auto" />
-          <span className="text-xl font-bold">PolySeek</span>
+          <Image src={(theme === 'dark' || (theme === 'system' && systemTheme === 'dark')) ? "/pslogo-white.svg" : "/pslogo.svg"} alt="PolySeek Logo" width={24} height={24} className="h-6 w-auto" />
+          <span className="text-xl font-bold text-gray-900 dark:text-white">PolySeek</span>
         </Link>
         <nav className="hidden md:flex items-center space-x-2">
           {status === "loading" && (

--- a/src/components/search/ProductSearch.tsx
+++ b/src/components/search/ProductSearch.tsx
@@ -460,12 +460,12 @@ export default function ProductSearch() {
 
 
   return (
-    <div className="p-4 bg-gray-100 border-b border-gray-200">
+    <div className="p-4 bg-gray-100 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
       <div className="container mx-auto flex items-center gap-2 md:gap-4">
         {/* Search Bar and Tag Input */}
         <div className="relative flex-grow" ref={searchInputRef}>
-          <div className="flex items-center border border-gray-300 rounded-md bg-white p-1 flex-wrap gap-1 min-h-[40px]">
-            <Search className="h-5 w-5 text-gray-400 mx-1 flex-shrink-0" />
+          <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 p-1 flex-wrap gap-1 min-h-[40px]">
+            <Search className="h-5 w-5 text-gray-400 dark:text-gray-300 mx-1 flex-shrink-0" />
             {selectedTags.map(tag => (
               <span key={tag} className="flex items-center bg-blue-100 text-blue-800 text-xs font-medium px-2 py-0.5 rounded whitespace-nowrap">
                 {tag}
@@ -493,7 +493,7 @@ export default function ProductSearch() {
             />
           </div>
           {isSuggestionsVisible && tagSuggestions.length > 0 && (
-            <ul ref={suggestionsRef} className="absolute z-20 w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-y-auto shadow-lg">
+            <ul ref={suggestionsRef} className="absolute z-20 w-full bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md mt-1 max-h-60 overflow-y-auto shadow-lg">
               {tagSuggestions.map(tag => (
                 <li
                   key={tag}


### PR DESCRIPTION
Issue #13と#14で報告された、ダークモード時のヘッダーと検索バーの背景色、およびロゴの表示に関する問題を修正しました。

- ヘッダーと検索バーの背景色がダークモード時に適切に切り替わるようにTailwind CSSのクラスを修正しました。
- ダークモード時に白色のロゴが表示されるように、`public/pslogo-white.svg`を作成し、`Header`コンポーネントでテーマに基づいてロゴを切り替えるロジックを追加しました。

関連Issue:
- #13
- #14
- #85