### PR TITLE
fix: 商品登録ページのレイアウトを修正

### DIFF
--- a/src/app/register-item/page.tsx
+++ b/src/app/register-item/page.tsx
@@ -210,7 +210,7 @@ export default function RegisterItemPage() {
   }, [featureTags]);
 
   return (
-    <div style={{ padding: '20px' }}>
+    <div className="container mx-auto px-4 py-8 pt-40">
       <h1>商品登録</h1>
 
       {/* URL入力フォーム */}


### PR DESCRIPTION
issue #91 および #92 に基づき、商品登録ページ (`src/app/register-item/page.tsx`) のレイアウトを修正しました。

ヘッダーコンポーネントと要素が重なって表示される問題を解決するため、既存のページ (`src/app/page.tsx` および `src/app/search/page.tsx`) の実装を参考に、メインコンテンツを囲む要素に `pt-40` クラスを追加しました。

これにより、ヘッダーの高さ分の適切な余白が設定され、UI要素が正しく表示されるようになります。