### PR TITLE
fix: デプロイ時のNode.jsバージョンをv22に固定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,9 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
           set -e
-          export PATH=/home/ubuntu/.nvm/versions/node/v22.17.0/bin:$PATH
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm use 22
           cd /home/ubuntu/PolySeek/
           git checkout -- package-lock.json
           git pull origin main


### PR DESCRIPTION
## 概要
デプロイ時のビルドエラーを解消するため、Node.jsのバージョンをv22.17.0に固定しました。

## 詳細
- `.github/workflows/deploy.yml`のSSH実行スクリプト内で、`export PATH`を使用してNode.js v22のパスを優先するように変更しました。
- これにより、`jsdom`などの依存関係が要求するNode.jsバージョンを満たし、ビルドエラーが解消されます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

このリリースでは、ユーザーに見える変更はありません。内部のデプロイメントワークフロー最適化のみです。

* **Chores**
  * デプロイ環境でのランタイム指定とパス設定を明確化し、デプロイの安定性を向上しました。
  * デプロイ後のアプリ再起動手順を簡素化し、運用時の信頼性を改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->