### PR TITLE
新規アカウント作成直後に利用規約同意フローを表示するよう改善

### DIFF
--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -51,7 +51,7 @@ export default function AuthGuard({ children }: { children: ReactNode }) {
         return null;
     }
 
-    // 認証済みだが未同意の場合、同意ページと除外ページ以外はコンテンツを表示しない
+    // 認証済みだが未同意の場合、規約/プライバシーページ（shouldForceAgreementがfalseになる）と同意ページ以外はコンテンツを表示しない
     if (shouldForceAgreement && !isAgreementPage) {
         return null;
     }


### PR DESCRIPTION
## 概要

新規アカウント作成直後に利用規約同意ページへ自動リダイレクトする機能を改善しました。

## 変更内容

### 問題

以前の実装では、`AuthGuard.tsx`がパブリックページ（`/`、`/search`等）では利用規約チェックをスキップしていたため、新規登録後にホームページに戻ると同意画面が表示されませんでした。

### 解決策

`AuthGuard.tsx`を修正し、認証済みかつ未同意のユーザーを**全てのページ**（`/terms`と`/privacy`以外）で同意ページへリダイレクトするよう変更しました。

- `/terms`と`/privacy`は例外として許可（同意画面から規約を確認できるようにするため）

## 変更ファイル

- `src/components/AuthGuard.tsx`

## 検証

- ✅ `npm run build` 成功
- ✅ 新規アカウントでログイン後、即座に同意ページへリダイレクトされることを確認
- ✅ 同意ボタンクリック後、正常に同意完了しホームへリダイレクトされることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * /terms と /privacy を常にアクセス可能に扱うよう改善しました。
  * 認証済みだが同意していないユーザーのリダイレクト挙動を見直し、同意ページや上記ページを除外して不要な遷移を防止しました。
  * 表示制御の判定を明確化し、未同意時のコンテンツブロックをより正確に適用するよう調整しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->