### PR TITLE
fix: Sentry Session Replay重複エラーを修正

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -23,11 +23,14 @@ Sentry.init({
   replaysSessionSampleRate: isProduction ? 0.1 : 1.0,
 
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
-  integrations: [
-    Sentry.replayIntegration({
-      // Additional Replay configuration goes in here, for example:
-      maskAllText: true,
-      blockAllMedia: true,
-    }),
-  ],
+  integrations: (integrations) => {
+    return [
+      ...integrations.filter((integration) => integration.name !== "Replay"),
+      Sentry.replayIntegration({
+        // Additional Replay configuration goes in here, for example:
+        maskAllText: true,
+        blockAllMedia: true,
+      }),
+    ];
+  },
 });


### PR DESCRIPTION
## 概要
`sentry.client.config.ts` で発生していた `Error: Multiple Sentry Session Replay instances are not supported` エラーを修正しました。
Sentry SDKの仕様により、自動的に追加されるデフォルトの `Replay` 統合と、設定ファイル内で手動追加した `Replay` 統合が重複してしまっていたことが原因です。

## 変更内容
- `sentry.client.config.ts` の `integrations` 設定を配列から関数形式に変更しました。
- 関数内で、既存の統合リストからデフォルトの `Replay` をフィルタリングして除外し、カスタム設定（`maskAllText: true` 等）を持つ新しい `Replay` 統合を追加するようにしました。

## 動作確認
- `npm run build` が正常に開始されることを確認（以前は設定読み込み時点でエラー）。
- 開発サーバー起動時にコンソールエラーが発生しないことを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Refactor**
  * エラー追跡機能の統合初期化処理を最適化。セッション記録機能の設定方法をアップデートし、カスタマイズオプションの適用が改善されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->