### PR TITLE
fix: Sentry Session Replayの重複インスタンス化を防止

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -6,31 +6,37 @@ import * as Sentry from "@sentry/nextjs";
 
 const isProduction = process.env.NODE_ENV === "production";
 
-Sentry.init({
-  enabled: process.env.NEXT_PUBLIC_SENTRY_ENABLED !== "false",
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+// Sentryが既に初期化済みの場合は再初期化をスキップ（重複インスタンス化を防止）
+if (Sentry.isInitialized()) {
+  // eslint-disable-next-line no-console
+  console.debug("Sentry is already initialized, skipping re-initialization");
+} else {
+  Sentry.init({
+    enabled: process.env.NEXT_PUBLIC_SENTRY_ENABLED !== "false",
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: isProduction ? 0.1 : 1.0,
+    // Adjust this value in production, or use tracesSampler for greater control
+    tracesSampleRate: isProduction ? 0.1 : 1.0,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: !isProduction,
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: !isProduction,
 
-  replaysOnErrorSampleRate: 1.0,
+    replaysOnErrorSampleRate: 1.0,
 
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: isProduction ? 0.1 : 1.0,
+    // This sets the sample rate to be 10%. You may want this to be 100% while
+    // in development and sample at a lower rate in production
+    replaysSessionSampleRate: isProduction ? 0.1 : 1.0,
 
-  // You can remove this option if you're not planning to use the Sentry Session Replay feature:
-  integrations: (integrations) => {
-    return [
-      ...integrations.filter((integration) => integration.name !== "Replay"),
-      Sentry.replayIntegration({
-        // Additional Replay configuration goes in here, for example:
-        maskAllText: true,
-        blockAllMedia: true,
-      }),
-    ];
-  },
-});
+    // You can remove this option if you're not planning to use the Sentry Session Replay feature:
+    integrations: (integrations) => {
+      return [
+        ...integrations.filter((integration) => integration.name !== "Replay"),
+        Sentry.replayIntegration({
+          // Additional Replay configuration goes in here, for example:
+          maskAllText: true,
+          blockAllMedia: true,
+        }),
+      ];
+    },
+  });
+}


### PR DESCRIPTION
## 概要

本番環境で発生していた `Multiple Sentry Session Replay instances are not supported` エラーを修正します。

## 問題

本番環境のコンソールに以下のエラーが出力されていました：

```
Uncaught Error: Multiple Sentry Session Replay instances are not supported
    at new rB (52774a7f-a241fda8423735df.js:2:33755)
    ...
```

## 原因

`Sentry.init()` が複数回呼び出され、Session Replay インテグレーションが重複してインスタンス化されていました。Next.js の本番ビルドでは、コード分割やチャンク読み込みにより、同じ設定ファイルが複数回実行される可能性があります。

## 解決策

`Sentry.isInitialized()` を使用したガード条件を追加し、Sentryが既に初期化されている場合は再初期化をスキップするようにしました。

```typescript
if (Sentry.isInitialized()) {
  console.debug("Sentry is already initialized, skipping re-initialization");
} else {
  Sentry.init({
    // ... 設定
  });
}
```

## 変更ファイル

- `sentry.client.config.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* エラー追跡機能の不要な再初期化を防止し、パフォーマンスと安定性を向上させました。システムは初期化状態を確認した上で、必要な場合のみ初期化処理を実行するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->