### PR TITLE
プライバシーポリシーにGoogle AnalyticsとSentryを追加

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -50,6 +50,20 @@ export default function PrivacyPage() {
       <ul className="list-disc pl-6 mb-4">
         <li>Google : アカウント認証のため</li>
         <li>Discord: アカウント認証のため</li>
+        <li>
+          Google Analytics（Google LLC）：サービス利用状況の分析のため。IPアドレス、ページビュー、サイト内の行動履歴等を収集します。詳細は
+          <a href="https://policies.google.com/technologies/partner-sites" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+            Googleのプライバシーポリシー
+          </a>
+          をご覧ください。
+        </li>
+        <li>
+          Sentry（Functional Software, Inc.）：エラー監視およびサービス品質向上のため。エラー発生時のデバイス情報、ブラウザ情報、エラー内容、操作のリプレイ（テキストおよびメディアはマスク処理）を収集します。詳細は
+          <a href="https://sentry.io/privacy/" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+            Sentryのプライバシーポリシー
+          </a>
+          をご覧ください。
+        </li>
       </ul>
 
       <h2 className="text-xl font-bold mt-8 mb-4">第5条（情報の収集モジュールと自動検知）</h2>


### PR DESCRIPTION
## 概要

SentryおよびGoogle Analytics導入に伴い、プライバシーポリシーの**第4条（外部送信・情報収集モジュール）**を更新しました。

## 変更内容

- プライバシーポリシー第4条に以下を追加:
  - **Google Analytics（Google LLC）**: サービス利用状況の分析
  - **Sentry（Functional Software, Inc.）**: エラー監視・サービス品質向上

## 変更理由

電気通信事業法の外部送信規律に対応するため、第三者へのデータ送信を行うサービスをプライバシーポリシーに明記する必要があります。

## 備考

- 利用規約は既存の免責条項でカバー済みのため、更新不要と判断しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * プライバシーポリシーを更新。Google AnalyticsとSentryに関する外部サービス情報、収集されるデータ、各サービスのプライバシーポリシーへのリンクを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->