### PR TITLE
fix: 商品登録時のタグ履歴をバージョン1として保存するように修正

### DIFF
--- a/src/app/api/items/create/route.ts
+++ b/src/app/api/items/create/route.ts
@@ -140,6 +140,16 @@ export async function POST(request: Request) {
                 isMain: variation.isMain,
               })),
             },
+            tagEditHistory: { // 初期タグ登録履歴 (Version 1) を作成
+              create: {
+                editorId: userId,
+                version: 1,
+                addedTags: tagIds,
+                removedTags: [],
+                keptTags: [],
+                comment: '初期登録',
+              },
+            },
           },
           include: {
             images: true,
@@ -150,6 +160,7 @@ export async function POST(request: Request) {
             },
             variations: true, // バリエーション情報もインクルード
             seller: true, // sellerリレーションを含める
+            tagEditHistory: true, // 作成された履歴も含める
           },
         });
     


### PR DESCRIPTION
## 概要
商品登録時に `TagEditHistory` を作成し、初期状態を「バージョン1」として保存するように修正しました。
これにより、次回以降のタグ編集が「バージョン2」として記録され、履歴の整合性が保たれます。

## 変更点
- `src/app/api/items/create/route.ts`: 商品作成トランザクション内に `tagEditHistory` の作成ロジックを追加。

## 関連Issue
- (なし)

## 検証
- 新規商品登録を行い、`TagEditHistory` が `version: 1` で作成されることを確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- 商品作成時にタグ編集履歴の記録が追加されました。編集者ID、バージョン、追加・削除・保持されたタグ、およびコメントが自動的に記録されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->