### PR TITLE
feat: モバイルヘッダーをハンバーガーメニューに変更

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -45,6 +45,7 @@ export default function Header() {
   const [prevScrollPos, setPrevScrollPos] = useState(0);
   type DialogType = 'register' | 'signup' | 'login' | null;
   const [activeDialog, setActiveDialog] = useState<DialogType>(null);
+  const [isSheetOpen, setIsSheetOpen] = useState(false); // Sheetの状態管理を追加
   const headerRef = useRef<HTMLElement>(null);
 
   const handleScroll = useCallback(() => {
@@ -95,7 +96,7 @@ export default function Header() {
 
            {/* Menu Trigger - Right Aligned */}
            <div className="ml-auto">
-             <Sheet>
+             <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
                <SheetTrigger asChild>
                  <Button variant="ghost" size="icon" aria-label="Menu">
                    <Menu className="h-6 w-6" />
@@ -137,9 +138,9 @@ export default function Header() {
                     </>
                   ) : (
                     <>
-                       <Button variant="ghost" className="w-full justify-start" onClick={() => setActiveDialog('register')}>商品登録</Button>
-                       <Button variant="ghost" className="w-full justify-start" onClick={() => setActiveDialog('signup')}>新規登録</Button>
-                       <Button variant="ghost" className="w-full justify-start" onClick={() => setActiveDialog('login')}>ログイン</Button>
+                       <Button variant="ghost" className="w-full justify-start" onClick={() => { setActiveDialog('register'); setIsSheetOpen(false); }}>商品登録</Button>
+                       <Button variant="ghost" className="w-full justify-start" onClick={() => { setActiveDialog('signup'); setIsSheetOpen(false); }}>新規登録</Button>
+                       <Button variant="ghost" className="w-full justify-start" onClick={() => { setActiveDialog('login'); setIsSheetOpen(false); }}>ログイン</Button>
                     </>
                   )}
                </div>


### PR DESCRIPTION
## 概要
モバイル表示時のヘッダーを最適化し、各種ボタンをハンバーガーメニュー内に移動しました。

## 変更点
- ヘッダーのレイアウト修正
- Shadcn UIのSheetコンポーネントを使用したハンバーガーメニューの実装
- ロゴの中央配置

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * モバイルメニューを右側のシート形式に刷新。ロゴを中央配置し、認証状態に応じて動的にメニュー項目を表示します。
  * 登録・サインアップ・ログインを単一のダイアログフローで統一し、モバイル／デスクトップで共通の操作に統合しました。
  * 読み込み時のスケルトン表示を追加し、スクリーンリーダー向けタイトルなどアクセシビリティを改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->