### PR TITLE
fix: TagDetailModalの幅をレスポンシブ対応 (95vw) に修正

### DIFF
--- a/src/components/TagDetailModal.tsx
+++ b/src/components/TagDetailModal.tsx
@@ -97,7 +97,7 @@ export function TagDetailModal({ tagId, open, onOpenChange }: TagDetailModalProp
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl h-[90vh] flex flex-col">
+      <DialogContent className="max-w-[95vw] md:max-w-3xl h-[90vh] flex flex-col">
         <DialogHeader>
           <div className="flex justify-between items-start pr-8">
             <DialogTitle>タグ詳細</DialogTitle>


### PR DESCRIPTION
## 概要
`TagDetailModal` の幅が固定値だったため、モバイル端末で適切な幅 (95vw) になるように修正しました。
前回のPR (#197) で漏れていた変更の追加対応です。

## 変更点
- `src/components/TagDetailModal.tsx`: `max-w-3xl` -> `max-w-[95vw] md:max-w-3xl`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ダイアログモーダルのコンテナ幅をレスポンシブデザインに対応させました。小さい画面では画面に適切に収まるよう調整され、中程度以上の画面サイズでは従来のサイズを維持するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->