### PR TITLE
商品詳細ページのモバイルレイアウト修正

### DIFF
--- a/src/app/products/[productId]/page.tsx
+++ b/src/app/products/[productId]/page.tsx
@@ -321,8 +321,8 @@ const ProductDetailPage = () => {
                       </CarouselItem>
                     ))}
                   </CarouselContent>
-                  <CarouselPrevious className="left-4" />
-                  <CarouselNext className="right-4" />
+                  <CarouselPrevious className="left-4 size-12 lg:size-8" />
+                  <CarouselNext className="right-4 size-12 lg:size-8" />
                 </Carousel>
                 <Carousel setApi={setThumbnailApi} opts={{ containScroll: 'keepSnaps', dragFree: true }} className="w-full mt-4">
                   <CarouselContent className="-ml-2">
@@ -351,7 +351,7 @@ const ProductDetailPage = () => {
           </main>
 
           <aside className="lg:col-span-4">
-            <div className="sticky top-header-desktop space-y-6">
+            <div className="lg:sticky lg:top-header-desktop space-y-6">
               <div className="p-6 bg-slate-50 dark:bg-slate-800/50 rounded-lg border dark:border-slate-700">
                 <h2 className="text-xl font-semibold mb-4">アクション</h2>
                 <div className="space-y-3">
@@ -414,7 +414,7 @@ const ProductDetailPage = () => {
                               タグ編集履歴を閲覧
                             </Button>
                           </DialogTrigger>
-                           <DialogContent className="max-w-4xl h-[90vh] flex flex-col">
+                           <DialogContent className="max-w-[95vw] sm:max-w-xl lg:max-w-3xl h-[90vh] flex flex-col">
                             <DialogHeader className="flex-shrink-0"><DialogTitle>タグ編集履歴</DialogTitle></DialogHeader>
                             <div className="flex-grow min-h-0">
                               <ScrollArea className="h-full">


### PR DESCRIPTION
## 概要
商品詳細ページにおけるモバイル表示時のレイアウト崩れを修正しました。

## 変更点
- サイドバーの追従設定をデスクトップのみ(`lg:sticky`)に変更
- カルーセル操作ボタンのサイズをモバイル向けに調整
- タグ編集履歴ダイアログの幅をレスポンシブ対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* 商品ページのカルーセルナビゲーションボタンのサイズをスクリーンサイズに応じて調整
* サイドバーの固定位置の動作をレスポンシブに最適化
* タグ履歴ダイアログの幅を複数のデバイスブレークポイントに対応

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->