### PR TITLE
fix: タグ編集履歴のタグ名表示不具合を修正

### DIFF
--- a/src/app/products/[productId]/page.tsx
+++ b/src/app/products/[productId]/page.tsx
@@ -62,7 +62,7 @@ const ProductDetailPage = () => {
   const productId = params.productId as string;
 
   const [product, setProduct] = useState<ProductDetail | null>(null);
-  const [tagMap, setTagMap] = useState<{ [key: string]: string }>({});
+  const [tagMap, setTagMap] = useState<{ [key: string]: { name: string; displayName: string | null } }>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [api, setApi] = useState<CarouselApi>();

--- a/src/components/MobileTagSheet.tsx
+++ b/src/components/MobileTagSheet.tsx
@@ -29,7 +29,7 @@ interface MobileTagSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   productTags: ProductTag[];
-  tagMap: { [key: string]: string };
+  tagMap: { [key: string]: { name: string; displayName: string | null } };
   tagEditHistory: TagEditHistory[];
   onAddTagToSearch: (tagName: string) => void;
   onAddNegativeTagToSearch: (tagName: string) => void;

--- a/src/components/TagEditHistoryItem.tsx
+++ b/src/components/TagEditHistoryItem.tsx
@@ -31,7 +31,7 @@ interface TagEditHistory {
 
 interface TagEditHistoryItemProps {
   history: TagEditHistory;
-  tagMap: { [key: string]: string };
+  tagMap: { [key: string]: { name: string; displayName: string | null } };
 }
 
 const TAG_DISPLAY_LIMIT = 5;
@@ -39,7 +39,7 @@ const TAG_DISPLAY_LIMIT = 5;
 const TagList: React.FC<{
   tagIds: string[],
   colorClass: string,
-  tagMap: { [key: string]: string }
+  tagMap: { [key: string]: { name: string; displayName: string | null } }
 }> = ({ tagIds, colorClass, tagMap }) => {
   const [showAll, setShowAll] = useState(false);
 
@@ -47,7 +47,10 @@ const TagList: React.FC<{
     return null;
   }
 
-  const tagNames = tagIds.map(id => tagMap[id] || id); // Fallback to ID if name not found
+  const tagNames = tagIds.map(id => {
+    const tagInfo = tagMap[id];
+    return tagInfo ? (tagInfo.displayName || tagInfo.name) : id;
+  }); // Fallback to ID if name not found
   const displayedTags = showAll ? tagNames : tagNames.slice(0, TAG_DISPLAY_LIMIT);
 
   return (


### PR DESCRIPTION
タグ編集履歴の画面で、変更されたタグが[Object] [Object]といった表示になっていた問題を修正しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * タグの表示名機能を追加しました。タグに表示名が設定されている場合、その表示名が優先的に表示されるようになります。タグ一覧やタグ編集履歴での表示がより明確になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->