### PR TITLE
fix: スマホブラウザからのログイン時Server Error修正

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs';
 
 import { handlers } from "@/auth"
 export const { GET, POST } = handlers

--- a/src/app/api/auth/agree/route.ts
+++ b/src/app/api/auth/agree/route.ts
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs';
 
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";


### PR DESCRIPTION
## 概要

スマホブラウザからログイン時に Server Error が発生する問題を修正しました。

## 原因

認証APIルート（`[...nextauth]/route.ts` と `agree/route.ts`）に `runtime = 'nodejs'` 設定が欠落しており、Edge Runtime で実行された場合に PrismaAdapter が動作しないためエラーが発生していました。

## 変更内容

- `src/app/api/auth/[...nextauth]/route.ts` に `runtime = 'nodejs'` を追加
- `src/app/api/auth/agree/route.ts` に `runtime = 'nodejs'` を追加

## 検証

- [ ] 本番環境にデプロイ後、スマホブラウザ（シークレットモード推奨）でログインを試行
- [ ] Server Error が発生しないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 認証関連のAPIルートの実行時設定を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->