### PR TITLE
fix: SafariでのOAuth認証エラーを修正

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -54,6 +54,42 @@ export const authConfig = {
                 secure: useSecureCookies,
             },
         },
+        // OAuth state/PKCE cookies - required for Safari ITP compatibility
+        state: {
+            name: useSecureCookies
+                ? `__Secure-authjs.state`
+                : `authjs.state`,
+            options: {
+                httpOnly: true,
+                sameSite: 'lax',
+                path: '/',
+                secure: useSecureCookies,
+                maxAge: 900, // 15 minutes
+            },
+        },
+        nonce: {
+            name: useSecureCookies
+                ? `__Secure-authjs.nonce`
+                : `authjs.nonce`,
+            options: {
+                httpOnly: true,
+                sameSite: 'lax',
+                path: '/',
+                secure: useSecureCookies,
+            },
+        },
+        pkceCodeVerifier: {
+            name: useSecureCookies
+                ? `__Secure-authjs.pkce.code_verifier`
+                : `authjs.pkce.code_verifier`,
+            options: {
+                httpOnly: true,
+                sameSite: 'lax',
+                path: '/',
+                secure: useSecureCookies,
+                maxAge: 900, // 15 minutes
+            },
+        },
     },
     callbacks: {
         async jwt({ token, user, trigger, session }) {


### PR DESCRIPTION
## 概要
SafariでGoogle認証を行う際に `error=Configuration` エラーが発生し、ログインできない問題を修正しました。

## 問題の原因
Safari の **Intelligent Tracking Prevention (ITP)** がOAuthフローに必要なCookieをブロックしていました。

具体的には、以下のCookie設定が不足していたため、Googleからのリダイレクト時にOAuthの状態検証に失敗していました：
- `state` - OAuthのステート管理（CSRF対策）
- `nonce` - OpenID Connectのリプレイ攻撃防止
- `pkceCodeVerifier` - PKCEフローのコード検証

## 変更内容
`src/auth.config.ts` にOAuthフローに必要な3つのCookie設定を追加：

| Cookie | 目的 |
|--------|------|
| `state` | OAuth状態管理 |
| `nonce` | リプレイ攻撃防止 |
| `pkceCodeVerifier` | PKCE検証 |

各Cookieに対して明示的な `sameSite: 'lax'` と `maxAge` を設定することで、SafariがOAuthリダイレクト時にこれらのCookieを正しく送信できるようになります。

## 検証方法
1. 本番環境にデプロイ
2. Safari（Mac/iOS）でログインフローをテスト
3. Google認証後、正常にリダイレクトされることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ強化**
  * OAuth認証プロセスのセキュリティを向上させるため、認証関連の保護機能を複数追加しました。これにより、より安全で堅牢なログイン体験が実現されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->