### PR TITLE
feat: 同一メールアドレスのOAuthアカウント自動リンク機能を追加

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -80,14 +80,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         user.name = existingUser.name;
         user.image = existingUser.image;
         // JWTコールバックで必要な追加フィールドをコピー
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (user as any).role = existingUser.role;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (user as any).status = existingUser.status;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (user as any).termsAgreedAt = existingUser.termsAgreedAt;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (user as any).isSafeSearchEnabled = existingUser.isSafeSearchEnabled;
+        user.role = existingUser.role;
+        user.status = existingUser.status;
+        user.termsAgreedAt = existingUser.termsAgreedAt;
+        user.isSafeSearchEnabled = existingUser.isSafeSearchEnabled;
 
         return true;
       } catch (error) {


### PR DESCRIPTION
## 概要
Google/Discordで同じメールアドレスを使用している場合に発生する「OAuthAccountNotLinked」エラーを解消し、自動的にアカウントをリンクしてログインできるようにしました。

## 変更内容
- `src/auth.ts` に `signIn` コールバックを追加
- 同一メールアドレスの既存ユーザーを検索し、異なるOAuthプロバイダーのアカウントを自動リンク
- リンク後は既存ユーザーとしてログイン処理を継続

## 動作フロー
1. ユーザーがGoogle/Discordでログインを試みる
2. 同一メールアドレスの既存ユーザーを検索
3. 既存ユーザーがいない場合 → 新規ユーザー作成（通常フロー）
4. 既存ユーザーがいて、同じプロバイダーのアカウントがある場合 → そのままログイン
5. 既存ユーザーがいて、異なるプロバイダーの場合 → 新しいAccountレコードを既存ユーザーに紐付けてログイン

## セキュリティ考慮
- GoogleとDiscordはどちらもメールアドレスを検証済みとして返すため、この実装は安全です
- 同一メールアドレスを信頼の根拠として自動リンクする一般的なパターン（GitHub、Notionなどで採用）

## テスト方法
- [ ] Googleで新規登録後、同じメールアドレスのDiscordでログインできることを確認
- [ ] Discordで新規登録後、同じメールアドレスのGoogleでログインできることを確認
- [ ] リンク後、どちらのプロバイダーでもログインできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * OAuthサインイン時の処理を強化し、メールが一致する既存ユーザーへ新しいプロバイダーを自動で連携できるようになりました。  
* **信頼性**
  * 連携処理をトランザクション内で再確認して競合を防止。セッション/JWTに反映されるユーザー情報（ID、名前、画像、権限、状態、利用同意、セーフサーチ設定等）が正しく更新されます。  
* **その他**
  * エラーは記録され、問題発生時はサインインが拒否されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->