### PR TITLE
feat: タグのカテゴリ別色分け表示機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "ts-node": "^10.9.1",
         "tsx": "^4.19.4",
         "tw-animate-css": "^1.2.9",
-        "typescript": "^5",
+        "typescript": "5.9.3",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^4.0.7"
       },
@@ -14764,6 +14764,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "ts-node": "^10.9.1",
     "tsx": "^4.19.4",
     "tw-animate-css": "^1.2.9",
-    "typescript": "^5",
+    "typescript": "5.9.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.0.7"
   },

--- a/src/app/api/products/[productId]/route.ts
+++ b/src/app/api/products/[productId]/route.ts
@@ -33,6 +33,7 @@ export async function GET(request: Request, context: { params: Promise<{ product
                   select: {
                     id: true,
                     name: true,
+                    color: true, // カテゴリ色を追加
                   },
                 },
               },

--- a/src/app/api/products/latest/route.ts
+++ b/src/app/api/products/latest/route.ts
@@ -85,6 +85,11 @@ export async function GET(request: Request) {
                 select: {
                   name: true,
                   displayName: true,
+                  tagCategory: {
+                    select: {
+                      color: true,
+                    },
+                  },
                 },
               },
             },
@@ -106,7 +111,10 @@ export async function GET(request: Request) {
       lowPrice: product.lowPrice,
       highPrice: product.highPrice,
       mainImageUrl: product.images.length > 0 ? product.images[0].imageUrl : null,
-      tags: product.productTags.map((pt) => pt.tag.displayName || pt.tag.name),
+      tags: product.productTags.map((pt) => ({
+        name: pt.tag.displayName || pt.tag.name,
+        categoryColor: pt.tag.tagCategory?.color || null,
+      })),
       variations: product.variations.map((v) => ({
         id: v.id,
         name: v.name,

--- a/src/app/profile/likes/page.tsx
+++ b/src/app/profile/likes/page.tsx
@@ -23,9 +23,14 @@ async function getLikedProducts(userId: string): Promise<Product[]> {
           productTags: {
             include: {
               tag: {
-                select: { 
+                select: {
                   name: true,
                   displayName: true,
+                  tagCategory: {
+                    select: {
+                      color: true,
+                    },
+                  },
                 },
               },
             },
@@ -51,7 +56,10 @@ async function getLikedProducts(userId: string): Promise<Product[]> {
       lowPrice: p.lowPrice,
       highPrice: p.highPrice,
       mainImageUrl: p.images.length > 0 ? p.images[0].imageUrl : null,
-      tags: p.productTags.map(pt => pt.tag.displayName || pt.tag.name),
+      tags: p.productTags.map(pt => ({
+        name: pt.tag.displayName || pt.tag.name,
+        categoryColor: pt.tag.tagCategory?.color || null,
+      })),
       isLiked: true, // It's the liked list, so this is always true
       isOwned: p.productOwners.length > 0,
       variations: p.variations.map(v => ({

--- a/src/app/profile/owned/page.tsx
+++ b/src/app/profile/owned/page.tsx
@@ -23,9 +23,14 @@ async function getOwnedProducts(userId: string): Promise<Product[]> {
           productTags: {
             include: {
               tag: {
-                select: { 
+                select: {
                   name: true,
                   displayName: true,
+                  tagCategory: {
+                    select: {
+                      color: true,
+                    },
+                  },
                 },
               },
             },
@@ -51,7 +56,10 @@ async function getOwnedProducts(userId: string): Promise<Product[]> {
       lowPrice: p.lowPrice,
       highPrice: p.highPrice,
       mainImageUrl: p.images.length > 0 ? p.images[0].imageUrl : null,
-      tags: p.productTags.map(pt => pt.tag.displayName || pt.tag.name),
+      tags: p.productTags.map(pt => ({
+        name: pt.tag.displayName || pt.tag.name,
+        categoryColor: pt.tag.tagCategory?.color || null,
+      })),
       isLiked: p.likes.length > 0,
       isOwned: true, // It's the owned list, so this is always true
       variations: p.variations.map(v => ({

--- a/src/app/users/[userId]/page.tsx
+++ b/src/app/users/[userId]/page.tsx
@@ -27,7 +27,17 @@ export default async function UserProfilePage({ params }: Props) {
           },
           productTags: {
             include: {
-              tag: true,
+              tag: {
+                select: {
+                  name: true,
+                  displayName: true,
+                  tagCategory: {
+                    select: {
+                      color: true,
+                    },
+                  },
+                },
+              },
             },
           },
           variations: true,
@@ -47,7 +57,10 @@ export default async function UserProfilePage({ params }: Props) {
     lowPrice: p.lowPrice,
     highPrice: p.highPrice,
     mainImageUrl: p.images.length > 0 ? p.images[0].imageUrl : null,
-    tags: p.productTags.map(pt => pt.tag.displayName || pt.tag.name),
+    tags: p.productTags.map(pt => ({
+      name: pt.tag.displayName || pt.tag.name,
+      categoryColor: pt.tag.tagCategory?.color || null,
+    })),
     variations: p.variations,
   }));
 

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import PriceDisplay from './PriceDisplay';
 import { Product } from "@/types/product";
 import { Heart, Archive } from 'lucide-react';
+import { CategoryTag } from '@/components/ui/category-tag';
 
 interface ProductCardProps {
   product: Product;
@@ -169,9 +170,12 @@ const ProductCard = ({ product, showLikeButton = false, showOwnButton = false, m
         )}
         <div className="flex flex-wrap gap-1 mb-2">
           {displayedTags.map((tag, index) => (
-            <span key={index} className="bg-blue-100 text-blue-800 text-xs font-medium px-2.5 py-0.5 rounded-full">
-              {tag}
-            </span>
+            <CategoryTag
+              key={index}
+              name={tag.name}
+              categoryColor={tag.categoryColor}
+              size="sm"
+            />
           ))}
         </div>
         <PriceDisplay product={product} />

--- a/src/components/ui/category-tag.tsx
+++ b/src/components/ui/category-tag.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useTheme } from 'next-themes';
+import { getTagStyle } from '@/lib/guidelines/categoryColors';
+import { cn } from '@/lib/utils';
+
+interface CategoryTagProps {
+  name: string;
+  categoryColor?: string | null;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+/**
+ * カテゴリ色に基づいたタグ表示コンポーネント
+ * ダークモード対応
+ */
+export function CategoryTag({
+  name,
+  categoryColor,
+  size = 'sm',
+  className,
+}: CategoryTagProps) {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  // ハイドレーション後にマウント状態を設定
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // SSR時はライトモードをデフォルトとして使用
+  const isDark = mounted ? resolvedTheme === 'dark' : false;
+  const style = getTagStyle(categoryColor || null, isDark);
+
+  const sizeClasses = {
+    sm: 'text-xs px-2.5 py-0.5',
+    md: 'text-sm px-3 py-1',
+  };
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full font-medium transition-colors',
+        sizeClasses[size],
+        className
+      )}
+      style={{
+        backgroundColor: style.backgroundColor,
+        color: style.color,
+      }}
+    >
+      {name}
+    </span>
+  );
+}

--- a/src/lib/guidelines/categoryColors.ts
+++ b/src/lib/guidelines/categoryColors.ts
@@ -96,3 +96,44 @@ export function getCategoryCardStyle(categoryName: string): {
     borderColor: `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`,
   };
 }
+
+/** デフォルトのグレー色（カテゴリ未設定時） */
+const DEFAULT_GRAY = '#6B7280';
+
+/**
+ * タグ表示用のスタイルを生成（薄い背景色 + テキスト色）
+ * ダークモード対応
+ * @param categoryColor - HEXカラーコード or null（未設定時）
+ * @param isDark - ダークモードかどうか
+ */
+export function getTagStyle(
+  categoryColor: string | null,
+  isDark: boolean = false
+): {
+  backgroundColor: string;
+  color: string;
+} {
+  const color = categoryColor || DEFAULT_GRAY;
+  const rgb = hexToRgb(color);
+
+  if (!rgb) {
+    // RGB変換に失敗した場合はデフォルトスタイル
+    return isDark
+      ? { backgroundColor: 'rgba(107, 114, 128, 0.3)', color: '#D1D5DB' }
+      : { backgroundColor: 'rgba(107, 114, 128, 0.15)', color: '#374151' };
+  }
+
+  if (isDark) {
+    // ダークモード: 背景をやや明るめに、テキストは明るい色
+    return {
+      backgroundColor: `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.25)`,
+      color: `rgb(${Math.min(255, rgb.r + 80)}, ${Math.min(255, rgb.g + 80)}, ${Math.min(255, rgb.b + 80)})`,
+    };
+  }
+
+  // ライトモード: 薄い背景 + 濃いテキスト
+  return {
+    backgroundColor: `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.15)`,
+    color: `rgb(${Math.max(0, rgb.r - 40)}, ${Math.max(0, rgb.g - 40)}, ${Math.max(0, rgb.b - 40)})`,
+  };
+}

--- a/src/lib/searchProducts.ts
+++ b/src/lib/searchProducts.ts
@@ -245,7 +245,15 @@ export async function searchProducts(params: SearchParams): Promise<SearchResult
         include: {
           productTags: {
             include: {
-              tag: true,
+              tag: {
+                include: {
+                  tagCategory: {
+                    select: {
+                      color: true,
+                    },
+                  },
+                },
+              },
             },
           },
           images: {
@@ -277,7 +285,10 @@ export async function searchProducts(params: SearchParams): Promise<SearchResult
         lowPrice: product.lowPrice,
         highPrice: product.highPrice,
         mainImageUrl: product.images.length > 0 ? product.images[0].imageUrl : null,
-        tags: product.productTags.map(pt => pt.tag.displayName || pt.tag.name),
+        tags: product.productTags.map(pt => ({
+          name: pt.tag.displayName || pt.tag.name,
+          categoryColor: pt.tag.tagCategory?.color || null,
+        })),
         variations: product.variations.map(v => ({
           id: v.id,
           name: v.name,

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,10 +1,18 @@
+/**
+ * タグ情報（カテゴリ色を含む）
+ */
+export interface TagInfo {
+  name: string;
+  categoryColor: string | null; // HEXカラーコード (例: "#E74C3C") or null
+}
+
 export interface Product {
   id: string;
   title:string;
   lowPrice: number;
   highPrice: number;
   mainImageUrl: string | null;
-  tags: string[];
+  tags: TagInfo[];
   isLiked?: boolean;
   isOwned?: boolean;
   ageRatingId?: string | null;
@@ -54,6 +62,7 @@ export interface ProductTag {
     tagCategory: {
       id: string;
       name: string;
+      color?: string; // カテゴリ色
     };
   };
   isOfficial: boolean; // BOOTH由来の公式タグかどうか


### PR DESCRIPTION
タグのカテゴリに基づいて色分け表示を行う機能を追加しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * タグにカテゴリカラーが表示されるようになりました。プロダクトカード、検索結果、ユーザープロファイルページでタグが色付けされて表示されます。
  * 新しいカテゴリーカラータグコンポーネントを追加し、統一されたタグ表示を実現しました。

* **Chores**
  * TypeScriptを5.9.3にアップデートしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->