### PR TITLE
feat: add tag proposal system (model, API, UI)

### DIFF
--- a/prisma/migrations/20260308150345_add_tag_proposal/migration.sql
+++ b/prisma/migrations/20260308150345_add_tag_proposal/migration.sql
@@ -1,0 +1,47 @@
+-- CreateEnum
+CREATE TYPE "ProposalType" AS ENUM ('CATEGORY', 'TRANSLATION', 'IMPLICATION');
+
+-- CreateEnum
+CREATE TYPE "ProposalStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- CreateTable
+CREATE TABLE "tag_proposals" (
+    "id" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    "proposerId" TEXT NOT NULL,
+    "type" "ProposalType" NOT NULL,
+    "status" "ProposalStatus" NOT NULL DEFAULT 'PENDING',
+    "reason" TEXT,
+    "categoryId" TEXT,
+    "existingTagId" TEXT,
+    "newTagName" TEXT,
+    "language" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tag_proposals_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "tag_proposals_tagId_idx" ON "tag_proposals"("tagId");
+
+-- CreateIndex
+CREATE INDEX "tag_proposals_proposerId_idx" ON "tag_proposals"("proposerId");
+
+-- CreateIndex
+CREATE INDEX "tag_proposals_status_idx" ON "tag_proposals"("status");
+
+-- CreateIndex
+CREATE INDEX "tag_proposals_type_idx" ON "tag_proposals"("type");
+
+-- AddForeignKey
+ALTER TABLE "tag_proposals" ADD CONSTRAINT "tag_proposals_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tag_proposals" ADD CONSTRAINT "tag_proposals_proposerId_fkey" FOREIGN KEY ("proposerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tag_proposals" ADD CONSTRAINT "tag_proposals_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "tag_categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tag_proposals" ADD CONSTRAINT "tag_proposals_existingTagId_fkey" FOREIGN KEY ("existingTagId") REFERENCES "Tag"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,7 @@ model User {
   reports       Report[]         // ユーザーが行った通報
   searchHistories SearchHistory[] // 検索履歴
   favorites       SearchFavorite[] // お気に入り検索
+  tagProposals    TagProposal[]   // ユーザーが行ったタグ提案
 
   @@index([name])
   @@index([email])
@@ -248,7 +249,9 @@ model Tag {
   metadataHistory TagMetadataHistory[]
   
   reports       Report[]         // このタグに対する通報
-  
+  proposals     TagProposal[]    @relation("ProposalTarget") // このタグに対する提案
+  proposalRefs  TagProposal[]    @relation("ProposalExistingTag") // 提案で参照されるタグ
+
   seller        Seller?          // クリエイタータグの場合の販売者情報
 }
 
@@ -386,6 +389,7 @@ model TagCategory {
   name      String    @unique // カテゴリ名
   color     String    // カテゴリの色 (例: '#FF0000')
   tags      Tag[]     // このカテゴリに属するタグ
+  proposals TagProposal[] // このカテゴリへの提案
 
   @@map("tag_categories") // データベース上のテーブル名
 }
@@ -402,6 +406,53 @@ model Seller {
   tag       Tag?      @relation(fields: [tagId], references: [id], onDelete: SetNull)
  
   @@map("sellers") // MongoDBの場合のコレクション名
+}
+
+// タグ提案の種別
+enum ProposalType {
+  CATEGORY
+  TRANSLATION
+  IMPLICATION
+}
+
+// タグ提案のステータス
+enum ProposalStatus {
+  PENDING
+  APPROVED
+  REJECTED
+}
+
+// タグ提案モデル
+model TagProposal {
+  id          String         @id @default(cuid())
+  tagId       String
+  tag         Tag            @relation("ProposalTarget", fields: [tagId], references: [id], onDelete: Cascade)
+  proposerId  String
+  proposer    User           @relation(fields: [proposerId], references: [id])
+  type        ProposalType
+  status      ProposalStatus @default(PENDING)
+  reason      String?        @db.Text
+
+  // CATEGORY用
+  categoryId  String?
+  category    TagCategory?   @relation(fields: [categoryId], references: [id])
+
+  // TRANSLATION/IMPLICATION用: 既存タグへの紐付け
+  existingTagId String?
+  existingTag   Tag?         @relation("ProposalExistingTag", fields: [existingTagId], references: [id])
+
+  // TRANSLATION/IMPLICATION用: 新規タグ提案
+  newTagName  String?
+  language    String?
+
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+
+  @@index([tagId])
+  @@index([proposerId])
+  @@index([status])
+  @@index([type])
+  @@map("tag_proposals")
 }
 
 // 通報の対象種別

--- a/src/app/api/tags/[tagId]/details/route.ts
+++ b/src/app/api/tags/[tagId]/details/route.ts
@@ -138,11 +138,11 @@ export async function GET(request: Request, { params }: { params: Promise<{ tagI
       ...tag,
       parentTags: parentTagRelations.map(pt => pt.parent),
       childTags: childTagRelations.map(ct => ct.child),
-      products: productRelations.map(p => ({
+      products: [...new Map(productRelations.map(p => [p.product.id, {
         id: p.product.id,
         title: p.product.title,
         mainImageUrl: p.product.images[0]?.imageUrl || null,
-      })),
+      }])).values()],
       history: history,
       hasReported,
     };

--- a/src/app/api/tags/[tagId]/proposals/__tests__/route.test.ts
+++ b/src/app/api/tags/[tagId]/proposals/__tests__/route.test.ts
@@ -1,0 +1,540 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockAuth, mockPrisma } = vi.hoisted(() => {
+  const mockAuth = vi.fn<() => Promise<any>>();
+  const mockPrisma = {
+    tag: { findUnique: vi.fn() },
+    tagCategory: { findUnique: vi.fn() },
+    tagProposal: { count: vi.fn(), create: vi.fn() },
+  };
+  return { mockAuth, mockPrisma };
+});
+
+vi.mock('@/auth', () => ({
+  auth: mockAuth,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: mockPrisma,
+}));
+
+import { POST } from '../route';
+
+type RouteContext = { params: Promise<{ tagId: string }> };
+
+function createRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/tags/test-tag-id/proposals', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function createContext(tagId: string): RouteContext {
+  return { params: Promise.resolve({ tagId }) };
+}
+
+describe('POST /api/tags/[tagId]/proposals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Authentication', () => {
+    it('should return 401 when not authenticated', async () => {
+      mockAuth.mockResolvedValueOnce(null);
+      const req = createRequest({ type: 'CATEGORY', categoryId: 'cat-1' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 401 when session has no user id', async () => {
+      mockAuth.mockResolvedValueOnce({ user: {} } as any);
+      const req = createRequest({ type: 'CATEGORY', categoryId: 'cat-1' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 403 when user is suspended', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'SUSPENDED' },
+      } as any);
+      const req = createRequest({ type: 'CATEGORY', categoryId: 'cat-1' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('Tag existence validation', () => {
+    it('should return 404 when tag does not exist', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce(null);
+      const req = createRequest({ type: 'CATEGORY', categoryId: 'cat-1' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('Validation - Category proposal', () => {
+    it('should return 400 when type is missing', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      const req = createRequest({ categoryId: 'cat-1' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 when type is invalid', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      const req = createRequest({ type: 'INVALID_TYPE' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 when categoryId is missing for CATEGORY type', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      const req = createRequest({ type: 'CATEGORY' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 when categoryId is empty string for CATEGORY type', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      const req = createRequest({ type: 'CATEGORY', categoryId: '' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('Validation - Translation proposal', () => {
+    it('should return 400 when neither existingTagId nor newTagName is provided for TRANSLATION', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      const req = createRequest({ type: 'TRANSLATION' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 when newTagName is provided without language for TRANSLATION', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      const req = createRequest({ type: 'TRANSLATION', newTagName: 'new-tag' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 when language is invalid for TRANSLATION with new tag', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      const req = createRequest({
+        type: 'TRANSLATION',
+        newTagName: 'new-tag',
+        language: 'fr',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should accept valid TRANSLATION proposal with existing tag', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-1',
+        type: 'TRANSLATION',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        existingTagId: 'existing-tag-id',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({
+        type: 'TRANSLATION',
+        existingTagId: 'existing-tag-id',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+    });
+
+    it('should accept valid TRANSLATION proposal with new tag name and language', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-2',
+        type: 'TRANSLATION',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        newTagName: 'hat',
+        language: 'en',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({
+        type: 'TRANSLATION',
+        newTagName: 'hat',
+        language: 'en',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('Validation - Implication proposal', () => {
+    it('should return 400 when neither existingTagId nor newTagName is provided for IMPLICATION', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      const req = createRequest({ type: 'IMPLICATION' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 when newTagName is provided without language for IMPLICATION', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      const req = createRequest({ type: 'IMPLICATION', newTagName: 'parent-tag' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('Validation - reason field', () => {
+    it('should accept proposal without reason (optional)', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-1',
+        type: 'CATEGORY',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        categoryId: 'cat-1',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({ type: 'CATEGORY', categoryId: 'cat-1' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+    });
+
+    it('should accept proposal with reason', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-2',
+        type: 'CATEGORY',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        categoryId: 'cat-1',
+        reason: 'This tag belongs to this category because...',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({
+        type: 'CATEGORY',
+        categoryId: 'cat-1',
+        reason: 'This tag belongs to this category because...',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+    });
+
+    it('should return 400 when reason exceeds 1000 characters', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      const longReason = 'a'.repeat(1001);
+      const req = createRequest({
+        type: 'CATEGORY',
+        categoryId: 'cat-1',
+        reason: longReason,
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('Rate limiting', () => {
+    it('should return 429 when rate limit exceeded', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(5);
+      const req = createRequest({ type: 'CATEGORY', categoryId: 'cat-1' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(429);
+    });
+
+    it('should allow request when under rate limit', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(2);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-1',
+        type: 'CATEGORY',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        categoryId: 'cat-1',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({ type: 'CATEGORY', categoryId: 'cat-1' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('Successful proposal creation', () => {
+    it('should create CATEGORY proposal and return 201', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-1',
+        type: 'CATEGORY',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        categoryId: 'cat-1',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({ type: 'CATEGORY', categoryId: 'cat-1' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.type).toBe('CATEGORY');
+      expect(data.status).toBe('PENDING');
+    });
+
+    it('should create TRANSLATION proposal with existing tag and return 201', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-2',
+        type: 'TRANSLATION',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        existingTagId: 'existing-trans-tag',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({
+        type: 'TRANSLATION',
+        existingTagId: 'existing-trans-tag',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.type).toBe('TRANSLATION');
+    });
+
+    it('should create TRANSLATION proposal with new tag name and return 201', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-3',
+        type: 'TRANSLATION',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        newTagName: 'hat',
+        language: 'en',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({
+        type: 'TRANSLATION',
+        newTagName: 'hat',
+        language: 'en',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.newTagName).toBe('hat');
+      expect(data.language).toBe('en');
+    });
+
+    it('should create IMPLICATION proposal with existing tag and return 201', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-4',
+        type: 'IMPLICATION',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        existingTagId: 'implied-tag-id',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({
+        type: 'IMPLICATION',
+        existingTagId: 'implied-tag-id',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.type).toBe('IMPLICATION');
+    });
+
+    it('should create IMPLICATION proposal with new tag and return 201', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-5',
+        type: 'IMPLICATION',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        newTagName: 'clothing',
+        language: 'en',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({
+        type: 'IMPLICATION',
+        newTagName: 'clothing',
+        language: 'en',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.newTagName).toBe('clothing');
+    });
+
+    it('should include reason in proposal when provided', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagProposal.create.mockResolvedValueOnce({
+        id: 'proposal-6',
+        type: 'CATEGORY',
+        tagId: 'tag-1',
+        proposerId: 'user-1',
+        categoryId: 'cat-1',
+        reason: 'Fits this category well',
+        status: 'PENDING',
+      } as any);
+      const req = createRequest({
+        type: 'CATEGORY',
+        categoryId: 'cat-1',
+        reason: 'Fits this category well',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.reason).toBe('Fits this category well');
+    });
+  });
+
+  describe('Duplicate proposal handling', () => {
+    it('should return 409 when duplicate proposal exists', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+
+      // Prisma unique constraint violation
+      const prismaError = new Error('Unique constraint failed');
+      (prismaError as any).code = 'P2002';
+      mockPrisma.tagProposal.create.mockRejectedValueOnce(prismaError);
+
+      const req = createRequest({ type: 'CATEGORY', categoryId: 'cat-1' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(409);
+    });
+  });
+});

--- a/src/app/api/tags/[tagId]/proposals/__tests__/route.test.ts
+++ b/src/app/api/tags/[tagId]/proposals/__tests__/route.test.ts
@@ -179,7 +179,9 @@ describe('POST /api/tags/[tagId]/proposals', () => {
       mockAuth.mockResolvedValueOnce({
         user: { id: 'user-1', status: 'ACTIVE' },
       } as any);
-      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tag.findUnique
+        .mockResolvedValueOnce({ id: 'tag-1' } as any)
+        .mockResolvedValueOnce({ id: 'existing-tag-id' } as any);
       mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
       mockPrisma.tagProposal.create.mockResolvedValueOnce({
         id: 'proposal-1',
@@ -259,6 +261,7 @@ describe('POST /api/tags/[tagId]/proposals', () => {
       } as any);
       mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
       mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagCategory.findUnique.mockResolvedValueOnce({ id: 'cat-1' } as any);
       mockPrisma.tagProposal.create.mockResolvedValueOnce({
         id: 'proposal-1',
         type: 'CATEGORY',
@@ -280,6 +283,7 @@ describe('POST /api/tags/[tagId]/proposals', () => {
       } as any);
       mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
       mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagCategory.findUnique.mockResolvedValueOnce({ id: 'cat-1' } as any);
       mockPrisma.tagProposal.create.mockResolvedValueOnce({
         id: 'proposal-2',
         type: 'CATEGORY',
@@ -338,6 +342,7 @@ describe('POST /api/tags/[tagId]/proposals', () => {
       } as any);
       mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
       mockPrisma.tagProposal.count.mockResolvedValueOnce(2);
+      mockPrisma.tagCategory.findUnique.mockResolvedValueOnce({ id: 'cat-1' } as any);
       mockPrisma.tagProposal.create.mockResolvedValueOnce({
         id: 'proposal-1',
         type: 'CATEGORY',
@@ -361,6 +366,7 @@ describe('POST /api/tags/[tagId]/proposals', () => {
       } as any);
       mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
       mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagCategory.findUnique.mockResolvedValueOnce({ id: 'cat-1' } as any);
       mockPrisma.tagProposal.create.mockResolvedValueOnce({
         id: 'proposal-1',
         type: 'CATEGORY',
@@ -383,7 +389,9 @@ describe('POST /api/tags/[tagId]/proposals', () => {
       mockAuth.mockResolvedValueOnce({
         user: { id: 'user-1', status: 'ACTIVE' },
       } as any);
-      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tag.findUnique
+        .mockResolvedValueOnce({ id: 'tag-1' } as any)
+        .mockResolvedValueOnce({ id: 'existing-trans-tag' } as any);
       mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
       mockPrisma.tagProposal.create.mockResolvedValueOnce({
         id: 'proposal-2',
@@ -438,7 +446,9 @@ describe('POST /api/tags/[tagId]/proposals', () => {
       mockAuth.mockResolvedValueOnce({
         user: { id: 'user-1', status: 'ACTIVE' },
       } as any);
-      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tag.findUnique
+        .mockResolvedValueOnce({ id: 'tag-1' } as any)
+        .mockResolvedValueOnce({ id: 'implied-tag-id' } as any);
       mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
       mockPrisma.tagProposal.create.mockResolvedValueOnce({
         id: 'proposal-4',
@@ -494,6 +504,7 @@ describe('POST /api/tags/[tagId]/proposals', () => {
       } as any);
       mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
       mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagCategory.findUnique.mockResolvedValueOnce({ id: 'cat-1' } as any);
       mockPrisma.tagProposal.create.mockResolvedValueOnce({
         id: 'proposal-6',
         type: 'CATEGORY',
@@ -517,24 +528,52 @@ describe('POST /api/tags/[tagId]/proposals', () => {
     });
   });
 
-  describe('Duplicate proposal handling', () => {
-    it('should return 409 when duplicate proposal exists', async () => {
+  describe('Error handling', () => {
+    it('should return 500 when create fails unexpectedly', async () => {
       mockAuth.mockResolvedValueOnce({
         user: { id: 'user-1', status: 'ACTIVE' },
       } as any);
       mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
       mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
-
-      // Prisma unique constraint violation
-      const prismaError = new Error('Unique constraint failed');
-      (prismaError as any).code = 'P2002';
-      mockPrisma.tagProposal.create.mockRejectedValueOnce(prismaError);
+      mockPrisma.tagCategory.findUnique.mockResolvedValueOnce({ id: 'cat-1' } as any);
+      mockPrisma.tagProposal.create.mockRejectedValueOnce(new Error('Database error'));
 
       const req = createRequest({ type: 'CATEGORY', categoryId: 'cat-1' });
 
       const res = await POST(req, createContext('tag-1'));
 
-      expect(res.status).toBe(409);
+      expect(res.status).toBe(500);
+    });
+
+    it('should return 404 when categoryId does not exist', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      mockPrisma.tagCategory.findUnique.mockResolvedValueOnce(null);
+
+      const req = createRequest({ type: 'CATEGORY', categoryId: 'non-existent' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 404 when existingTagId does not exist', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique
+        .mockResolvedValueOnce({ id: 'tag-1' } as any)
+        .mockResolvedValueOnce(null);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+
+      const req = createRequest({ type: 'TRANSLATION', existingTagId: 'non-existent' });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/src/app/api/tags/[tagId]/proposals/__tests__/route.test.ts
+++ b/src/app/api/tags/[tagId]/proposals/__tests__/route.test.ts
@@ -528,6 +528,44 @@ describe('POST /api/tags/[tagId]/proposals', () => {
     });
   });
 
+  describe('Self-reference validation', () => {
+    it('should return 400 when existingTagId equals tagId for TRANSLATION', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      const req = createRequest({
+        type: 'TRANSLATION',
+        existingTagId: 'tag-1',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain('自分自身');
+    });
+
+    it('should return 400 when existingTagId equals tagId for IMPLICATION', async () => {
+      mockAuth.mockResolvedValueOnce({
+        user: { id: 'user-1', status: 'ACTIVE' },
+      } as any);
+      mockPrisma.tag.findUnique.mockResolvedValueOnce({ id: 'tag-1' } as any);
+      mockPrisma.tagProposal.count.mockResolvedValueOnce(0);
+      const req = createRequest({
+        type: 'IMPLICATION',
+        existingTagId: 'tag-1',
+      });
+
+      const res = await POST(req, createContext('tag-1'));
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain('自分自身');
+    });
+  });
+
   describe('Error handling', () => {
     it('should return 500 when create fails unexpectedly', async () => {
       mockAuth.mockResolvedValueOnce({

--- a/src/app/api/tags/[tagId]/proposals/route.ts
+++ b/src/app/api/tags/[tagId]/proposals/route.ts
@@ -165,6 +165,12 @@ export async function POST(req: Request, context: RouteContext) {
       createData.category = { connect: { id: validatedData.categoryId } };
     } else {
       if (validatedData.existingTagId) {
+        if (validatedData.existingTagId === tagId) {
+          return NextResponse.json(
+            { error: '自分自身を参照先として指定することはできません' },
+            { status: 400 }
+          );
+        }
         const existingTag = await prisma.tag.findUnique({
           where: { id: validatedData.existingTagId },
           select: { id: true },

--- a/src/app/api/tags/[tagId]/proposals/route.ts
+++ b/src/app/api/tags/[tagId]/proposals/route.ts
@@ -1,0 +1,188 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+import { PROPOSAL_ERROR_MESSAGES } from '@/lib/constants/messages';
+import {
+  PROPOSAL_RATE_LIMIT_MAX,
+  PROPOSAL_RATE_LIMIT_WINDOW_MS,
+  PROPOSAL_REASON_MAX_LENGTH,
+  PROPOSAL_SUPPORTED_LANGUAGES,
+} from '@/lib/constants';
+
+const reasonField = z.string().max(PROPOSAL_REASON_MAX_LENGTH).optional();
+
+const tagRefFields = {
+  existingTagId: z.string().min(1).optional(),
+  newTagName: z.string().min(1).optional(),
+  language: z.enum(PROPOSAL_SUPPORTED_LANGUAGES).optional(),
+  reason: reasonField,
+};
+
+const tagRefRefinements = [
+  {
+    check: (data: { existingTagId?: string; newTagName?: string }) =>
+      Boolean(data.existingTagId || data.newTagName),
+    message: 'existingTagId or newTagName is required',
+  },
+  {
+    check: (data: { newTagName?: string; language?: string }) =>
+      !data.newTagName || Boolean(data.language),
+    message: 'language is required when newTagName is provided',
+  },
+] as const;
+
+const categorySchema = z.object({
+  type: z.literal('CATEGORY'),
+  categoryId: z.string().min(1),
+  reason: reasonField,
+});
+
+const translationBaseSchema = z.object({
+  type: z.literal('TRANSLATION'),
+  ...tagRefFields,
+});
+
+const implicationBaseSchema = z.object({
+  type: z.literal('IMPLICATION'),
+  ...tagRefFields,
+});
+
+const translationSchema = translationBaseSchema
+  .refine(tagRefRefinements[0].check, { message: tagRefRefinements[0].message })
+  .refine(tagRefRefinements[1].check, { message: tagRefRefinements[1].message });
+
+const implicationSchema = implicationBaseSchema
+  .refine(tagRefRefinements[0].check, { message: tagRefRefinements[0].message })
+  .refine(tagRefRefinements[1].check, { message: tagRefRefinements[1].message });
+
+// discriminatedUnion requires plain z.object (no refinements)
+const proposalSchema = z.discriminatedUnion('type', [
+  categorySchema,
+  translationBaseSchema,
+  implicationBaseSchema,
+]);
+
+type RouteContext = { params: Promise<{ tagId: string }> };
+
+export async function POST(req: Request, context: RouteContext) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: PROPOSAL_ERROR_MESSAGES.UNAUTHORIZED },
+        { status: 401 }
+      );
+    }
+
+    if (session.user.status === 'SUSPENDED') {
+      return NextResponse.json(
+        { error: PROPOSAL_ERROR_MESSAGES.ACCOUNT_SUSPENDED },
+        { status: 403 }
+      );
+    }
+
+    const { tagId } = await context.params;
+
+    const tag = await prisma.tag.findUnique({ where: { id: tagId } });
+    if (!tag) {
+      return NextResponse.json(
+        { error: PROPOSAL_ERROR_MESSAGES.TAG_NOT_FOUND },
+        { status: 404 }
+      );
+    }
+
+    const body = await req.json();
+
+    // Step 1: discriminatedUnion for basic type + field validation
+    const baseValidation = proposalSchema.safeParse(body);
+    if (!baseValidation.success) {
+      return NextResponse.json(
+        { error: baseValidation.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    // Step 2: type-specific refinement validation
+    const { type } = baseValidation.data;
+    if (type === 'TRANSLATION') {
+      const result = translationSchema.safeParse(body);
+      if (!result.success) {
+        return NextResponse.json(
+          { error: result.error.flatten() },
+          { status: 400 }
+        );
+      }
+    } else if (type === 'IMPLICATION') {
+      const result = implicationSchema.safeParse(body);
+      if (!result.success) {
+        return NextResponse.json(
+          { error: result.error.flatten() },
+          { status: 400 }
+        );
+      }
+    }
+
+    const validatedData = baseValidation.data;
+
+    // Rate limiting
+    const windowStart = new Date(Date.now() - PROPOSAL_RATE_LIMIT_WINDOW_MS);
+    const recentCount = await prisma.tagProposal.count({
+      where: {
+        proposerId: session.user.id,
+        createdAt: { gt: windowStart },
+      },
+    });
+
+    if (recentCount >= PROPOSAL_RATE_LIMIT_MAX) {
+      return NextResponse.json(
+        { error: PROPOSAL_ERROR_MESSAGES.TOO_MANY_PROPOSALS },
+        { status: 429 }
+      );
+    }
+
+    // Build create data based on type
+    const createData: Prisma.TagProposalCreateInput = {
+      tag: { connect: { id: tagId } },
+      proposer: { connect: { id: session.user.id } },
+      type,
+      reason: validatedData.reason,
+    };
+
+    if (validatedData.type === 'CATEGORY') {
+      createData.category = { connect: { id: validatedData.categoryId } };
+    } else {
+      if (validatedData.existingTagId) {
+        createData.existingTag = { connect: { id: validatedData.existingTagId } };
+      }
+      if (validatedData.newTagName) {
+        createData.newTagName = validatedData.newTagName;
+        createData.language = validatedData.language;
+      }
+    }
+
+    const proposal = await prisma.tagProposal.create({
+      data: createData,
+    });
+
+    return NextResponse.json(proposal, { status: 201 });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      (error as { code: string }).code === 'P2002'
+    ) {
+      return NextResponse.json(
+        { error: PROPOSAL_ERROR_MESSAGES.DUPLICATE_PROPOSAL },
+        { status: 409 }
+      );
+    }
+    console.error('Error creating tag proposal:', error);
+    return NextResponse.json(
+      { error: PROPOSAL_ERROR_MESSAGES.INTERNAL_SERVER_ERROR },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tags/[tagId]/proposals/route.ts
+++ b/src/app/api/tags/[tagId]/proposals/route.ts
@@ -23,8 +23,8 @@ const tagRefFields = {
 const tagRefRefinements = [
   {
     check: (data: { existingTagId?: string; newTagName?: string }) =>
-      Boolean(data.existingTagId || data.newTagName),
-    message: 'existingTagId or newTagName is required',
+      Boolean(data.existingTagId) !== Boolean(data.newTagName),
+    message: 'existingTagId か newTagName のどちらか一方のみを指定してください',
   },
   {
     check: (data: { newTagName?: string; language?: string }) =>
@@ -152,9 +152,29 @@ export async function POST(req: Request, context: RouteContext) {
     };
 
     if (validatedData.type === 'CATEGORY') {
+      const categoryExists = await prisma.tagCategory.findUnique({
+        where: { id: validatedData.categoryId },
+        select: { id: true },
+      });
+      if (!categoryExists) {
+        return NextResponse.json(
+          { error: '指定されたカテゴリが見つかりません' },
+          { status: 404 }
+        );
+      }
       createData.category = { connect: { id: validatedData.categoryId } };
     } else {
       if (validatedData.existingTagId) {
+        const existingTag = await prisma.tag.findUnique({
+          where: { id: validatedData.existingTagId },
+          select: { id: true },
+        });
+        if (!existingTag) {
+          return NextResponse.json(
+            { error: PROPOSAL_ERROR_MESSAGES.TAG_NOT_FOUND },
+            { status: 404 }
+          );
+        }
         createData.existingTag = { connect: { id: validatedData.existingTagId } };
       }
       if (validatedData.newTagName) {
@@ -169,16 +189,6 @@ export async function POST(req: Request, context: RouteContext) {
 
     return NextResponse.json(proposal, { status: 201 });
   } catch (error) {
-    if (
-      error instanceof Error &&
-      'code' in error &&
-      (error as { code: string }).code === 'P2002'
-    ) {
-      return NextResponse.json(
-        { error: PROPOSAL_ERROR_MESSAGES.DUPLICATE_PROPOSAL },
-        { status: 409 }
-      );
-    }
     console.error('Error creating tag proposal:', error);
     return NextResponse.json(
       { error: PROPOSAL_ERROR_MESSAGES.INTERNAL_SERVER_ERROR },

--- a/src/components/TagDetailModal.tsx
+++ b/src/components/TagDetailModal.tsx
@@ -111,7 +111,13 @@ export function TagDetailModal({ tagId, open, onOpenChange }: TagDetailModalProp
               <div className="flex gap-1">
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="inline-block" tabIndex={session?.user?.status === 'SUSPENDED' ? 0 : -1}>
+                  <span
+                    className="inline-block"
+                    tabIndex={session?.user?.status === 'SUSPENDED' ? 0 : -1}
+                    role={session?.user?.status === 'SUSPENDED' ? "button" : undefined}
+                    aria-label={session?.user?.status === 'SUSPENDED' ? "アカウントが停止されています" : undefined}
+                    aria-disabled={session?.user?.status === 'SUSPENDED' ? true : undefined}
+                  >
                     <Button
                       variant="ghost"
                       size="icon"

--- a/src/components/TagDetailModal.tsx
+++ b/src/components/TagDetailModal.tsx
@@ -22,8 +22,9 @@ import { Tag, TagMetadataHistory } from '@prisma/client';
 import { REPORT_TARGET_TAG } from '@/lib/constants';
 import Link from 'next/link';
 import Image from 'next/image';
-import { Flag } from 'lucide-react';
+import { Flag, Lightbulb } from 'lucide-react';
 import { ReportDialog } from './reports/ReportDialog';
+import { TagProposalDialog } from './proposals/TagProposalDialog';
 
 // Extend Tag type to include API-returned displayName
 type TagWithDisplayName = Tag & { displayName?: string };
@@ -55,6 +56,7 @@ export function TagDetailModal({ tagId, open, onOpenChange }: TagDetailModalProp
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [isReportOpen, setIsReportOpen] = useState(false);
+  const [isProposalOpen, setIsProposalOpen] = useState(false);
 
   const fetchDetails = async (id: string) => {
     setLoading(true);
@@ -105,8 +107,25 @@ export function TagDetailModal({ tagId, open, onOpenChange }: TagDetailModalProp
           <div className="flex justify-between items-start pr-8">
             <DialogTitle>タグ詳細</DialogTitle>
             {details && session?.user && (
-              // Note: Tags are global entities and do not have an owner, so we don't check for ownership here.
-              // Users can report any tag unless they are suspended or have already reported it.
+              <div className="flex gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-muted-foreground hover:text-primary"
+                    onClick={() => setIsProposalOpen(true)}
+                    aria-label={session?.user?.status === 'SUSPENDED' ? "アカウントが停止されています" : "タグの提案をする"}
+                    disabled={session?.user?.status === 'SUSPENDED'}
+                    data-testid="proposal-tag-button"
+                  >
+                    <Lightbulb className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{session?.user?.status === 'SUSPENDED' ? "アカウントが停止されています" : "タグの提案をする"}</p>
+                </TooltipContent>
+              </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="inline-block" tabIndex={details.hasReported || session?.user?.status === 'SUSPENDED' ? 0 : -1}>
@@ -127,6 +146,7 @@ export function TagDetailModal({ tagId, open, onOpenChange }: TagDetailModalProp
                   <p>{session?.user?.status === 'SUSPENDED' ? "アカウントが停止されています" : details.hasReported ? "既に通報済みです" : "このタグを通報する"}</p>
                 </TooltipContent>
               </Tooltip>
+              </div>
             )}
           </div>
         </DialogHeader>
@@ -217,6 +237,12 @@ export function TagDetailModal({ tagId, open, onOpenChange }: TagDetailModalProp
               targetType={REPORT_TARGET_TAG}
               targetId={details.id}
               targetName={details.name}
+            />
+            <TagProposalDialog
+              open={isProposalOpen}
+              onOpenChange={setIsProposalOpen}
+              tagId={details.id}
+              tagName={details.displayName || details.name}
             />
           </>
         )}

--- a/src/components/TagDetailModal.tsx
+++ b/src/components/TagDetailModal.tsx
@@ -86,6 +86,7 @@ export function TagDetailModal({ tagId, open, onOpenChange }: TagDetailModalProp
   };
 
   useEffect(() => {
+    setIsProposalOpen(false);
     if (open && tagId) {
       fetchDetails(tagId);
     } else {
@@ -110,17 +111,19 @@ export function TagDetailModal({ tagId, open, onOpenChange }: TagDetailModalProp
               <div className="flex gap-1">
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="text-muted-foreground hover:text-primary"
-                    onClick={() => setIsProposalOpen(true)}
-                    aria-label={session?.user?.status === 'SUSPENDED' ? "アカウントが停止されています" : "タグの提案をする"}
-                    disabled={session?.user?.status === 'SUSPENDED'}
-                    data-testid="proposal-tag-button"
-                  >
-                    <Lightbulb className="h-4 w-4" />
-                  </Button>
+                  <span className="inline-block" tabIndex={session?.user?.status === 'SUSPENDED' ? 0 : -1}>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="text-muted-foreground hover:text-primary"
+                      onClick={() => setIsProposalOpen(true)}
+                      aria-label={session?.user?.status === 'SUSPENDED' ? "アカウントが停止されています" : "タグの提案をする"}
+                      disabled={session?.user?.status === 'SUSPENDED'}
+                      data-testid="proposal-tag-button"
+                    >
+                      <Lightbulb className="h-4 w-4" />
+                    </Button>
+                  </span>
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>{session?.user?.status === 'SUSPENDED' ? "アカウントが停止されています" : "タグの提案をする"}</p>

--- a/src/components/proposals/CategoryProposalForm.tsx
+++ b/src/components/proposals/CategoryProposalForm.tsx
@@ -27,6 +27,7 @@ export function CategoryProposalForm({ onDataChange }: CategoryProposalFormProps
   const [categoryId, setCategoryId] = useState("");
   const [reason, setReason] = useState("");
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchCategories = async () => {
@@ -35,7 +36,11 @@ export function CategoryProposalForm({ onDataChange }: CategoryProposalFormProps
         if (res.ok) {
           const data = await res.json();
           setCategories(data);
+        } else {
+          setError("カテゴリの取得に失敗しました");
         }
+      } catch {
+        setError("カテゴリの取得に失敗しました");
       } finally {
         setLoading(false);
       }
@@ -56,6 +61,9 @@ export function CategoryProposalForm({ onDataChange }: CategoryProposalFormProps
 
   return (
     <div className="grid gap-4">
+      {error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
       <div className="grid gap-2">
         <Label htmlFor="category-select">カテゴリ</Label>
         <Select value={categoryId} onValueChange={setCategoryId} disabled={loading}>

--- a/src/components/proposals/CategoryProposalForm.tsx
+++ b/src/components/proposals/CategoryProposalForm.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { PROPOSAL_REASON_MAX_LENGTH } from "@/lib/constants";
+
+interface TagCategory {
+  id: string;
+  name: string;
+  color: string;
+}
+
+interface CategoryProposalFormProps {
+  onDataChange: (data: { categoryId: string; reason?: string } | null) => void;
+}
+
+export function CategoryProposalForm({ onDataChange }: CategoryProposalFormProps) {
+  const [categories, setCategories] = useState<TagCategory[]>([]);
+  const [categoryId, setCategoryId] = useState("");
+  const [reason, setReason] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const res = await fetch("/api/categories");
+        if (res.ok) {
+          const data = await res.json();
+          setCategories(data);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  useEffect(() => {
+    if (categoryId) {
+      onDataChange({
+        categoryId,
+        reason: reason.trim() || undefined,
+      });
+    } else {
+      onDataChange(null);
+    }
+  }, [categoryId, reason, onDataChange]);
+
+  return (
+    <div className="grid gap-4">
+      <div className="grid gap-2">
+        <Label htmlFor="category-select">カテゴリ</Label>
+        <Select value={categoryId} onValueChange={setCategoryId} disabled={loading}>
+          <SelectTrigger id="category-select">
+            <SelectValue placeholder={loading ? "読み込み中..." : "カテゴリを選択"} />
+          </SelectTrigger>
+          <SelectContent>
+            {categories.map((cat) => (
+              <SelectItem key={cat.id} value={cat.id}>
+                <span className="flex items-center gap-2">
+                  <span
+                    className="inline-block w-3 h-3 rounded-full"
+                    style={{ backgroundColor: cat.color }}
+                  />
+                  {cat.name}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="category-reason">理由（任意）</Label>
+        <Textarea
+          id="category-reason"
+          placeholder="この提案の理由を入力してください..."
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          maxLength={PROPOSAL_REASON_MAX_LENGTH}
+          className="min-h-[80px]"
+        />
+        <div className="text-right text-xs text-muted-foreground">
+          {reason.length} / {PROPOSAL_REASON_MAX_LENGTH}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/proposals/ImplicationProposalForm.tsx
+++ b/src/components/proposals/ImplicationProposalForm.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { TagSearchProposalForm, type TagSearchProposalFormData } from "./TagSearchProposalForm";
+
+interface ImplicationProposalFormProps {
+  onDataChange: (data: TagSearchProposalFormData | null) => void;
+}
+
+export function ImplicationProposalForm({ onDataChange }: ImplicationProposalFormProps) {
+  return (
+    <TagSearchProposalForm
+      onDataChange={onDataChange}
+      idPrefix="impl"
+      newTagPlaceholder="含意タグ名を入力..."
+    />
+  );
+}

--- a/src/components/proposals/TagProposalDialog.tsx
+++ b/src/components/proposals/TagProposalDialog.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CategoryProposalForm } from "./CategoryProposalForm";
+import { TranslationProposalForm } from "./TranslationProposalForm";
+import { ImplicationProposalForm } from "./ImplicationProposalForm";
+import type { TagSearchProposalFormData } from "./TagSearchProposalForm";
+import {
+  PROPOSAL_TYPE_CATEGORY,
+  PROPOSAL_TYPE_TRANSLATION,
+  PROPOSAL_TYPE_IMPLICATION,
+  type ProposalType,
+} from "@/lib/constants";
+import { toast } from "sonner";
+
+function extractErrorMessage(error: unknown): string {
+  if (typeof error === 'string') return error;
+  if (typeof error === 'object' && error !== null) {
+    const obj = error as Record<string, unknown>;
+    if (Array.isArray(obj.formErrors) && obj.formErrors.length > 0) {
+      return obj.formErrors.join(', ');
+    }
+    if (obj.fieldErrors && typeof obj.fieldErrors === 'object') {
+      const messages = Object.values(obj.fieldErrors as Record<string, string[]>)
+        .flat()
+        .filter(Boolean);
+      if (messages.length > 0) return messages.join(', ');
+    }
+  }
+  return '提案の送信に失敗しました。';
+}
+
+interface TagProposalDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tagId: string;
+  tagName: string;
+}
+
+export function TagProposalDialog({
+  open,
+  onOpenChange,
+  tagId,
+  tagName,
+}: TagProposalDialogProps) {
+  const [activeTab, setActiveTab] = useState<ProposalType>(PROPOSAL_TYPE_CATEGORY);
+  type FormData = { categoryId: string; reason?: string } | TagSearchProposalFormData;
+  const [formData, setFormData] = useState<FormData | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    if (!nextOpen) {
+      setActiveTab(PROPOSAL_TYPE_CATEGORY);
+      setFormData(null);
+      setIsSubmitting(false);
+    }
+    onOpenChange(nextOpen);
+  }, [onOpenChange]);
+
+  const handleDataChange = useCallback((data: FormData | null) => {
+    setFormData(data);
+  }, []);
+
+  const handleSubmit = async () => {
+    if (!formData) return;
+
+    setIsSubmitting(true);
+    try {
+      const response = await fetch(`/api/tags/${tagId}/proposals`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: activeTab, ...formData }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        const message = extractErrorMessage(data.error);
+        throw new Error(message);
+      }
+
+      toast.success("提案を送信しました。ご協力ありがとうございます。");
+      handleOpenChange(false);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "提案の送信に失敗しました。";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>タグ提案: {tagName}</DialogTitle>
+          <DialogDescription>
+            このタグに対する提案を送信してください。管理者が確認後に反映されます。
+          </DialogDescription>
+        </DialogHeader>
+        <Tabs
+          value={activeTab}
+          onValueChange={(v) => {
+            setActiveTab(v as ProposalType);
+            setFormData(null);
+          }}
+        >
+          <TabsList className="w-full">
+            <TabsTrigger value={PROPOSAL_TYPE_CATEGORY}>カテゴリ</TabsTrigger>
+            <TabsTrigger value={PROPOSAL_TYPE_TRANSLATION}>翻訳</TabsTrigger>
+            <TabsTrigger value={PROPOSAL_TYPE_IMPLICATION}>含意</TabsTrigger>
+          </TabsList>
+          <TabsContent value={PROPOSAL_TYPE_CATEGORY} className="mt-4">
+            <CategoryProposalForm onDataChange={handleDataChange} />
+          </TabsContent>
+          <TabsContent value={PROPOSAL_TYPE_TRANSLATION} className="mt-4">
+            <TranslationProposalForm onDataChange={handleDataChange} />
+          </TabsContent>
+          <TabsContent value={PROPOSAL_TYPE_IMPLICATION} className="mt-4">
+            <ImplicationProposalForm onDataChange={handleDataChange} />
+          </TabsContent>
+        </Tabs>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={isSubmitting}
+          >
+            キャンセル
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isSubmitting || !formData}
+          >
+            {isSubmitting ? "送信中..." : "送信"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/proposals/TagSearchProposalForm.tsx
+++ b/src/components/proposals/TagSearchProposalForm.tsx
@@ -50,7 +50,7 @@ export function TagSearchProposalForm({
       return;
     }
     try {
-      const res = await fetch(`/api/tags/search?q=${encodeURIComponent(query)}&limit=10`);
+      const res = await fetch(`/api/tags/search?query=${encodeURIComponent(query)}`);
       if (res.ok) {
         const data = await res.json();
         setSearchResults(data.tags || data);

--- a/src/components/proposals/TagSearchProposalForm.tsx
+++ b/src/components/proposals/TagSearchProposalForm.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  PROPOSAL_REASON_MAX_LENGTH,
+  PROPOSAL_SUPPORTED_LANGUAGES,
+} from "@/lib/constants";
+
+export interface TagSearchProposalFormData {
+  existingTagId?: string;
+  newTagName?: string;
+  language?: string;
+  reason?: string;
+}
+
+interface TagSearchProposalFormProps {
+  onDataChange: (data: TagSearchProposalFormData | null) => void;
+  idPrefix: string;
+  newTagPlaceholder: string;
+}
+
+type InputMode = "existing" | "new";
+
+export function TagSearchProposalForm({
+  onDataChange,
+  idPrefix,
+  newTagPlaceholder,
+}: TagSearchProposalFormProps) {
+  const [mode, setMode] = useState<InputMode>("existing");
+  const [existingTagId, setExistingTagId] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<{ id: string; name: string }[]>([]);
+  const [newTagName, setNewTagName] = useState("");
+  const [language, setLanguage] = useState("");
+  const [reason, setReason] = useState("");
+
+  const searchTags = useCallback(async (query: string) => {
+    if (query.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+    try {
+      const res = await fetch(`/api/tags/search?q=${encodeURIComponent(query)}&limit=10`);
+      if (res.ok) {
+        const data = await res.json();
+        setSearchResults(data.tags || data);
+      }
+    } catch {
+      setSearchResults([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    const timer = setTimeout(() => searchTags(searchQuery), 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery, searchTags]);
+
+  useEffect(() => {
+    const reasonTrimmed = reason.trim() || undefined;
+
+    if (mode === "existing" && existingTagId) {
+      onDataChange({ existingTagId, reason: reasonTrimmed });
+    } else if (mode === "new" && newTagName.trim() && language) {
+      onDataChange({ newTagName: newTagName.trim(), language, reason: reasonTrimmed });
+    } else {
+      onDataChange(null);
+    }
+  }, [mode, existingTagId, newTagName, language, reason, onDataChange]);
+
+  return (
+    <div className="grid gap-4">
+      <div className="grid gap-2">
+        <Label>入力方式</Label>
+        <Select value={mode} onValueChange={(v) => setMode(v as InputMode)}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="existing">既存タグから選択</SelectItem>
+            <SelectItem value="new">新しいタグ名を入力</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {mode === "existing" ? (
+        <div className="grid gap-2">
+          <Label htmlFor={`${idPrefix}-tag-search`}>タグ検索</Label>
+          <Input
+            id={`${idPrefix}-tag-search`}
+            placeholder="タグ名を入力して検索..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          {searchResults.length > 0 && (
+            <div className="border rounded-md max-h-32 overflow-y-auto">
+              {searchResults.map((tag) => (
+                <button
+                  key={tag.id}
+                  type="button"
+                  className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent ${
+                    existingTagId === tag.id ? "bg-accent font-medium" : ""
+                  }`}
+                  onClick={() => setExistingTagId(tag.id)}
+                >
+                  {tag.name}
+                </button>
+              ))}
+            </div>
+          )}
+          {existingTagId && (
+            <p className="text-sm text-muted-foreground">
+              選択中: {searchResults.find((t) => t.id === existingTagId)?.name || existingTagId}
+            </p>
+          )}
+        </div>
+      ) : (
+        <>
+          <div className="grid gap-2">
+            <Label htmlFor={`${idPrefix}-new-tag-name`}>新しいタグ名</Label>
+            <Input
+              id={`${idPrefix}-new-tag-name`}
+              placeholder={newTagPlaceholder}
+              value={newTagName}
+              onChange={(e) => setNewTagName(e.target.value)}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor={`${idPrefix}-language-select`}>言語</Label>
+            <Select value={language} onValueChange={setLanguage}>
+              <SelectTrigger id={`${idPrefix}-language-select`}>
+                <SelectValue placeholder="言語を選択" />
+              </SelectTrigger>
+              <SelectContent>
+                {PROPOSAL_SUPPORTED_LANGUAGES.map((lang) => (
+                  <SelectItem key={lang} value={lang}>
+                    {lang === "ja" ? "日本語" : "English"}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </>
+      )}
+
+      <div className="grid gap-2">
+        <Label htmlFor={`${idPrefix}-reason`}>理由（任意）</Label>
+        <Textarea
+          id={`${idPrefix}-reason`}
+          placeholder="この提案の理由を入力してください..."
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          maxLength={PROPOSAL_REASON_MAX_LENGTH}
+          className="min-h-[80px]"
+        />
+        <div className="text-right text-xs text-muted-foreground">
+          {reason.length} / {PROPOSAL_REASON_MAX_LENGTH}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/proposals/TranslationProposalForm.tsx
+++ b/src/components/proposals/TranslationProposalForm.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { TagSearchProposalForm, type TagSearchProposalFormData } from "./TagSearchProposalForm";
+
+interface TranslationProposalFormProps {
+  onDataChange: (data: TagSearchProposalFormData | null) => void;
+}
+
+export function TranslationProposalForm({ onDataChange }: TranslationProposalFormProps) {
+  return (
+    <TagSearchProposalForm
+      onDataChange={onDataChange}
+      idPrefix="translation"
+      newTagPlaceholder="翻訳タグ名を入力..."
+    />
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -19,6 +19,29 @@ export const ReportStatus = {
 
 export type ReportStatus = (typeof ReportStatus)[keyof typeof ReportStatus];
 
+// Proposal Types
+export const PROPOSAL_TYPE_CATEGORY = 'CATEGORY' as const;
+export const PROPOSAL_TYPE_TRANSLATION = 'TRANSLATION' as const;
+export const PROPOSAL_TYPE_IMPLICATION = 'IMPLICATION' as const;
+
+export const PROPOSAL_TYPES = [
+  PROPOSAL_TYPE_CATEGORY,
+  PROPOSAL_TYPE_TRANSLATION,
+  PROPOSAL_TYPE_IMPLICATION,
+] as const;
+
+export type ProposalType = typeof PROPOSAL_TYPES[number];
+
+// Proposal Rate Limit
+export const PROPOSAL_RATE_LIMIT_MAX = 5;
+export const PROPOSAL_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+
+// Proposal Reason
+export const PROPOSAL_REASON_MAX_LENGTH = 1000;
+
+// Supported languages for tag proposals
+export const PROPOSAL_SUPPORTED_LANGUAGES = ['ja', 'en'] as const;
+
 export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://polyseek.jp';
 
 // Stale run recovery: Mark RUNNING records older than this as FAILED

--- a/src/lib/constants/__tests__/messages-usage.test.ts
+++ b/src/lib/constants/__tests__/messages-usage.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { REPORT_ERROR_MESSAGES, PROPOSAL_ERROR_MESSAGES } from '../messages';
+
+// AR-005/AR-006 再発防止: 定義された定数は全て使用されていることを保証する
+// 未使用のキーが追加された場合、このテストが定数オブジェクトの構造を検証する
+
+describe('REPORT_ERROR_MESSAGES', () => {
+  it('should only contain expected keys', () => {
+    const expectedKeys = [
+      'UNAUTHORIZED',
+      'ACCOUNT_SUSPENDED',
+      'TOO_MANY_REPORTS',
+      'OWN_PRODUCT',
+      'OWN_TAG',
+      'INVALID_TARGET_TYPE',
+      'ALREADY_REPORTED',
+      'INTERNAL_SERVER_ERROR',
+    ];
+    expect(Object.keys(REPORT_ERROR_MESSAGES).sort()).toEqual(
+      expectedKeys.sort(),
+    );
+  });
+
+  it('should have non-empty string values for all keys', () => {
+    for (const [key, value] of Object.entries(REPORT_ERROR_MESSAGES)) {
+      expect(value, `${key} should be a non-empty string`).toBeTruthy();
+      expect(typeof value).toBe('string');
+    }
+  });
+});
+
+describe('PROPOSAL_ERROR_MESSAGES', () => {
+  it('should only contain expected keys', () => {
+    const expectedKeys = [
+      'UNAUTHORIZED',
+      'ACCOUNT_SUSPENDED',
+      'TAG_NOT_FOUND',
+      'TOO_MANY_PROPOSALS',
+      'DUPLICATE_PROPOSAL',
+      'INTERNAL_SERVER_ERROR',
+    ];
+    expect(Object.keys(PROPOSAL_ERROR_MESSAGES).sort()).toEqual(
+      expectedKeys.sort(),
+    );
+  });
+
+  it('should have non-empty string values for all keys', () => {
+    for (const [key, value] of Object.entries(PROPOSAL_ERROR_MESSAGES)) {
+      expect(value, `${key} should be a non-empty string`).toBeTruthy();
+      expect(typeof value).toBe('string');
+    }
+  });
+});

--- a/src/lib/constants/messages.ts
+++ b/src/lib/constants/messages.ts
@@ -1,11 +1,19 @@
 export const REPORT_ERROR_MESSAGES = {
   UNAUTHORIZED: 'ログインが必要です',
   ACCOUNT_SUSPENDED: 'アカウントが停止されています',
-  VALIDATION_ERROR: '入力内容に誤りがあります',
   TOO_MANY_REPORTS: '短期間に多くの通報が行われました。しばらく待ってから再度お試しください。',
   OWN_PRODUCT: '自分の商品は通報できません',
   OWN_TAG: '自分が付けたタグは通報できません',
   INVALID_TARGET_TYPE: '無効な通報対象です',
   ALREADY_REPORTED: 'この対象は既に通報済みです',
+  INTERNAL_SERVER_ERROR: 'サーバーエラーが発生しました',
+} as const;
+
+export const PROPOSAL_ERROR_MESSAGES = {
+  UNAUTHORIZED: 'ログインが必要です',
+  ACCOUNT_SUSPENDED: 'アカウントが停止されています',
+  TAG_NOT_FOUND: '指定されたタグが見つかりません',
+  TOO_MANY_PROPOSALS: '短期間に多くの提案が行われました。しばらく待ってから再度お試しください。',
+  DUPLICATE_PROPOSAL: '同じ内容の提案が既に存在します',
   INTERNAL_SERVER_ERROR: 'サーバーエラーが発生しました',
 } as const;

--- a/tests/integration/tag-proposal.test.ts
+++ b/tests/integration/tag-proposal.test.ts
@@ -13,8 +13,6 @@ describe('TagProposal Feature Integration Tests', () => {
       where: {
         proposer: { email: testEmail },
       },
-    }).catch(() => {
-      // tagProposal table may not exist yet during TDD
     });
     await prisma.tag.deleteMany({
       where: {

--- a/tests/integration/tag-proposal.test.ts
+++ b/tests/integration/tag-proposal.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { prisma } from '@/lib/prisma';
+
+describe('TagProposal Feature Integration Tests', () => {
+  const testEmail = 'test-proposal@example.com';
+  const testTagName = 'TestProposalTag';
+  const testTranslationTagName = 'TestTranslationTag';
+  const testCategoryName = 'TestProposalCategory';
+
+  const cleanup = async () => {
+    // Clean up in reverse dependency order
+    await prisma.tagProposal.deleteMany({
+      where: {
+        proposer: { email: testEmail },
+      },
+    }).catch(() => {
+      // tagProposal table may not exist yet during TDD
+    });
+    await prisma.tag.deleteMany({
+      where: {
+        name: { in: [testTagName, testTranslationTagName] },
+      },
+    });
+    await prisma.tagCategory.deleteMany({
+      where: { name: testCategoryName },
+    });
+    await prisma.user.deleteMany({
+      where: { email: testEmail },
+    });
+  };
+
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it('should create a CATEGORY proposal in the database', async () => {
+    // Given: user, tag, and category exist
+    const user = await prisma.user.create({
+      data: {
+        name: 'Test User',
+        email: testEmail,
+        role: 'USER',
+        termsAgreedAt: new Date(),
+      },
+    });
+
+    const tag = await prisma.tag.create({
+      data: { name: testTagName, language: 'ja' },
+    });
+
+    const category = await prisma.tagCategory.create({
+      data: { name: testCategoryName, color: '#FF0000' },
+    });
+
+    // When: a category proposal is created
+    const proposal = await prisma.tagProposal.create({
+      data: {
+        proposerId: user.id,
+        tagId: tag.id,
+        type: 'CATEGORY',
+        categoryId: category.id,
+        status: 'PENDING',
+      },
+    });
+
+    // Then: proposal is saved correctly
+    expect(proposal).toBeTruthy();
+    expect(proposal.type).toBe('CATEGORY');
+    expect(proposal.status).toBe('PENDING');
+    expect(proposal.tagId).toBe(tag.id);
+    expect(proposal.proposerId).toBe(user.id);
+    expect(proposal.categoryId).toBe(category.id);
+  }, 15000);
+
+  it('should create a TRANSLATION proposal with existing tag', async () => {
+    // Given: user and two tags exist
+    const user = await prisma.user.create({
+      data: {
+        name: 'Test User',
+        email: testEmail,
+        role: 'USER',
+        termsAgreedAt: new Date(),
+      },
+    });
+
+    const sourceTag = await prisma.tag.create({
+      data: { name: testTagName, language: 'ja' },
+    });
+
+    const translationTag = await prisma.tag.create({
+      data: { name: testTranslationTagName, language: 'en' },
+    });
+
+    // When: a translation proposal is created referencing existing tag
+    const proposal = await prisma.tagProposal.create({
+      data: {
+        proposerId: user.id,
+        tagId: sourceTag.id,
+        type: 'TRANSLATION',
+        existingTagId: translationTag.id,
+        status: 'PENDING',
+      },
+    });
+
+    // Then: proposal references both tags
+    expect(proposal.type).toBe('TRANSLATION');
+    expect(proposal.tagId).toBe(sourceTag.id);
+    expect(proposal.existingTagId).toBe(translationTag.id);
+  }, 15000);
+
+  it('should create a TRANSLATION proposal with new tag name', async () => {
+    // Given: user and source tag exist
+    const user = await prisma.user.create({
+      data: {
+        name: 'Test User',
+        email: testEmail,
+        role: 'USER',
+        termsAgreedAt: new Date(),
+      },
+    });
+
+    const tag = await prisma.tag.create({
+      data: { name: testTagName, language: 'ja' },
+    });
+
+    // When: a translation proposal with new tag name is created
+    const proposal = await prisma.tagProposal.create({
+      data: {
+        proposerId: user.id,
+        tagId: tag.id,
+        type: 'TRANSLATION',
+        newTagName: 'hat',
+        language: 'en',
+        status: 'PENDING',
+      },
+    });
+
+    // Then: proposal stores new tag name and language
+    expect(proposal.type).toBe('TRANSLATION');
+    expect(proposal.newTagName).toBe('hat');
+    expect(proposal.language).toBe('en');
+    expect(proposal.existingTagId).toBeNull();
+  }, 15000);
+
+  it('should create an IMPLICATION proposal', async () => {
+    // Given: user and two tags exist
+    const user = await prisma.user.create({
+      data: {
+        name: 'Test User',
+        email: testEmail,
+        role: 'USER',
+        termsAgreedAt: new Date(),
+      },
+    });
+
+    const implyingTag = await prisma.tag.create({
+      data: { name: testTagName, language: 'ja' },
+    });
+
+    const impliedTag = await prisma.tag.create({
+      data: { name: testTranslationTagName, language: 'ja' },
+    });
+
+    // When: an implication proposal is created
+    const proposal = await prisma.tagProposal.create({
+      data: {
+        proposerId: user.id,
+        tagId: implyingTag.id,
+        type: 'IMPLICATION',
+        existingTagId: impliedTag.id,
+        status: 'PENDING',
+      },
+    });
+
+    // Then: proposal is saved with IMPLICATION type
+    expect(proposal.type).toBe('IMPLICATION');
+    expect(proposal.tagId).toBe(implyingTag.id);
+    expect(proposal.existingTagId).toBe(impliedTag.id);
+  }, 15000);
+
+  it('should query proposal with its relationships', async () => {
+    // Given: a proposal exists
+    const user = await prisma.user.create({
+      data: {
+        name: 'Test User',
+        email: testEmail,
+        role: 'USER',
+        termsAgreedAt: new Date(),
+      },
+    });
+
+    const tag = await prisma.tag.create({
+      data: { name: testTagName, language: 'ja' },
+    });
+
+    const category = await prisma.tagCategory.create({
+      data: { name: testCategoryName, color: '#00FF00' },
+    });
+
+    await prisma.tagProposal.create({
+      data: {
+        proposerId: user.id,
+        tagId: tag.id,
+        type: 'CATEGORY',
+        categoryId: category.id,
+        reason: 'This tag fits the category',
+        status: 'PENDING',
+      },
+    });
+
+    // When: querying with relations
+    const proposals = await prisma.tagProposal.findMany({
+      where: { proposerId: user.id },
+      include: {
+        proposer: true,
+        tag: true,
+        category: true,
+      },
+    });
+
+    // Then: relationships are loaded
+    expect(proposals).toHaveLength(1);
+    const proposal = proposals[0];
+    expect(proposal.proposer).toBeDefined();
+    expect(proposal.proposer?.id).toBe(user.id);
+    expect(proposal.tag).toBeDefined();
+    expect(proposal.tag.name).toBe(testTagName);
+    expect(proposal.category).toBeDefined();
+    expect(proposal.category?.name).toBe(testCategoryName);
+    expect(proposal.reason).toBe('This tag fits the category');
+  }, 15000);
+
+  it('should reject proposal with non-existent proposerId', async () => {
+    // Given: non-existent user
+    const tag = await prisma.tag.create({
+      data: { name: testTagName, language: 'ja' },
+    });
+
+    // When/Then: foreign key constraint prevents creation
+    await expect(
+      prisma.tagProposal.create({
+        data: {
+          proposerId: 'non-existent-user-id',
+          tagId: tag.id,
+          type: 'CATEGORY',
+          status: 'PENDING',
+        },
+      })
+    ).rejects.toThrow();
+  }, 15000);
+
+  it('should reject proposal with non-existent tagId', async () => {
+    // Given: user exists but tag does not
+    const user = await prisma.user.create({
+      data: {
+        name: 'Test User',
+        email: testEmail,
+        role: 'USER',
+        termsAgreedAt: new Date(),
+      },
+    });
+
+    // When/Then: foreign key constraint prevents creation
+    await expect(
+      prisma.tagProposal.create({
+        data: {
+          proposerId: user.id,
+          tagId: 'non-existent-tag-id',
+          type: 'CATEGORY',
+          status: 'PENDING',
+        },
+      })
+    ).rejects.toThrow();
+  }, 15000);
+
+  it('should handle proposal status transitions', async () => {
+    // Given: a pending proposal
+    const user = await prisma.user.create({
+      data: {
+        name: 'Test User',
+        email: testEmail,
+        role: 'USER',
+        termsAgreedAt: new Date(),
+      },
+    });
+
+    const tag = await prisma.tag.create({
+      data: { name: testTagName, language: 'ja' },
+    });
+
+    const proposal = await prisma.tagProposal.create({
+      data: {
+        proposerId: user.id,
+        tagId: tag.id,
+        type: 'CATEGORY',
+        status: 'PENDING',
+      },
+    });
+    expect(proposal.status).toBe('PENDING');
+
+    // When: status is updated to APPROVED
+    const approved = await prisma.tagProposal.update({
+      where: { id: proposal.id },
+      data: { status: 'APPROVED' },
+    });
+
+    // Then: status reflects the change
+    expect(approved.status).toBe('APPROVED');
+
+    // When: create another and reject it
+    const proposal2 = await prisma.tagProposal.create({
+      data: {
+        proposerId: user.id,
+        tagId: tag.id,
+        type: 'IMPLICATION',
+        newTagName: 'test-implied',
+        language: 'ja',
+        status: 'PENDING',
+      },
+    });
+
+    const rejected = await prisma.tagProposal.update({
+      where: { id: proposal2.id },
+      data: { status: 'REJECTED' },
+    });
+
+    expect(rejected.status).toBe('REJECTED');
+  }, 15000);
+
+  it('should store optional reason field', async () => {
+    // Given: user and tag
+    const user = await prisma.user.create({
+      data: {
+        name: 'Test User',
+        email: testEmail,
+        role: 'USER',
+        termsAgreedAt: new Date(),
+      },
+    });
+
+    const tag = await prisma.tag.create({
+      data: { name: testTagName, language: 'ja' },
+    });
+
+    // When: proposal without reason
+    const withoutReason = await prisma.tagProposal.create({
+      data: {
+        proposerId: user.id,
+        tagId: tag.id,
+        type: 'CATEGORY',
+        status: 'PENDING',
+      },
+    });
+
+    // Then: reason is null
+    expect(withoutReason.reason).toBeNull();
+
+    // When: proposal with reason
+    const withReason = await prisma.tagProposal.create({
+      data: {
+        proposerId: user.id,
+        tagId: tag.id,
+        type: 'IMPLICATION',
+        existingTagId: tag.id,
+        reason: 'Because these tags are related',
+        status: 'PENDING',
+      },
+    });
+
+    // Then: reason is stored
+    expect(withReason.reason).toBe('Because these tags are related');
+  }, 15000);
+});


### PR DESCRIPTION
## Summary
- ユーザーがタグのカテゴリ変更・翻訳追加・implication提案を投稿できる機能を実装
- TagProposalデータモデル（Prismaスキーマ）を追加
- 提案用APIエンドポイントを追加
- UIダイアログ・フォームコンポーネント（5種）を追加
- 定数・メッセージの整理とテストを追加

## Test plan
- [ ] TagProposalモデルのマイグレーションが正常に実行されることを確認
- [ ] 提案APIのCRUD操作が正しく動作することを確認
- [ ] UIコンポーネントからの提案投稿フローを確認
- [ ] テストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * タグ提案ワークフローを追加（カテゴリ／翻訳／含意の提出、提出ダイアログ、既存タグ選択や新規タグ名・言語指定、理由入力、UIボタン）。
  * クライアントとサーバーで提案タイプごとの検証、ステータス管理、レート制限を導入。

* **テスト**
  * API単体・統合・ユニットテストを大幅追加し主要ケースとエラーパスを網羅。

* **Chores**
  * データベースに提案用スキーマ（列挙型・テーブル・制約・索引）を追加。
  * エラーメッセージ定数を整理・追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->