### PR TITLE
feat: add tag implication backend (admin API, cycle detection, auto-apply)

### DIFF
--- a/src/app/admin/tag-implications/page.tsx
+++ b/src/app/admin/tag-implications/page.tsx
@@ -1,0 +1,20 @@
+import { isAdmin } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import AdminLayout from "@/components/admin/AdminLayout";
+import TagImplicationManager from "@/components/admin/TagImplicationManager";
+
+const TagImplicationsPage = async () => {
+  const userIsAdmin = await isAdmin();
+
+  if (!userIsAdmin) {
+    redirect("/");
+  }
+
+  return (
+    <AdminLayout>
+      <TagImplicationManager />
+    </AdminLayout>
+  );
+};
+
+export default TagImplicationsPage;

--- a/src/app/api/admin/tag-implications/__tests__/route.test.ts
+++ b/src/app/api/admin/tag-implications/__tests__/route.test.ts
@@ -21,6 +21,13 @@ vi.mock('@/lib/prisma', () => ({
     tag: {
       findUnique: (...args: unknown[]) => mockTagFindUnique(...args),
     },
+    $transaction: (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        tagImplication: {
+          create: (...args: unknown[]) => mockImplicationCreate(...args),
+          findUnique: (...args: unknown[]) => mockImplicationFindUnique(...args),
+        },
+      }),
   },
 }));
 
@@ -299,15 +306,18 @@ describe('POST /api/admin/tag-implications', () => {
   });
 
   it('should return 409 when duplicate implication exists', async () => {
-    // Given: admin user, valid tags, no cycle, but duplicate exists
+    // Given: admin user, valid tags, no cycle, but unique constraint violation on create
     mockIsAdmin.mockResolvedValueOnce(true);
     mockTagFindUnique
       .mockResolvedValueOnce({ id: 'tag-a', name: 'panties' })
       .mockResolvedValueOnce({ id: 'tag-b', name: 'clothing' });
     mockWouldCreateCycle.mockResolvedValueOnce(false);
-    mockImplicationFindUnique.mockResolvedValueOnce({
-      id: 'existing-impl',
-    }); // duplicate found
+    mockImplicationCreate.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: '1',
+      })
+    );
 
     // When: creating duplicate implication
     const request = new Request('http://localhost/api/admin/tag-implications', {

--- a/src/app/api/admin/tag-implications/__tests__/route.test.ts
+++ b/src/app/api/admin/tag-implications/__tests__/route.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Prisma } from '@prisma/client';
+
+// Prisma mocks
+const mockImplicationFindMany = vi.fn();
+const mockImplicationCreate = vi.fn();
+const mockImplicationDelete = vi.fn();
+const mockImplicationFindUnique = vi.fn();
+const mockImplicationCount = vi.fn();
+const mockTagFindUnique = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    tagImplication: {
+      findMany: (...args: unknown[]) => mockImplicationFindMany(...args),
+      create: (...args: unknown[]) => mockImplicationCreate(...args),
+      delete: (...args: unknown[]) => mockImplicationDelete(...args),
+      findUnique: (...args: unknown[]) => mockImplicationFindUnique(...args),
+      count: (...args: unknown[]) => mockImplicationCount(...args),
+    },
+    tag: {
+      findUnique: (...args: unknown[]) => mockTagFindUnique(...args),
+    },
+  },
+}));
+
+// Auth mock
+const mockIsAdmin = vi.fn();
+vi.mock('@/lib/auth', () => ({
+  isAdmin: () => mockIsAdmin(),
+}));
+
+// wouldCreateCycle mock
+const mockWouldCreateCycle = vi.fn();
+vi.mock('@/lib/tagImplication', () => ({
+  wouldCreateCycle: (...args: unknown[]) => mockWouldCreateCycle(...args),
+}));
+
+const { GET, POST, DELETE } = await import('../route');
+
+describe('GET /api/admin/tag-implications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 403 when user is not admin', async () => {
+    // Given: non-admin user
+    mockIsAdmin.mockResolvedValueOnce(false);
+
+    // When: making GET request
+    const request = new Request('http://localhost/api/admin/tag-implications');
+    const response = await GET(request);
+
+    // Then: forbidden
+    expect(response.status).toBe(403);
+  });
+
+  it('should return implications list with tag details', async () => {
+    // Given: admin user and existing implications
+    mockIsAdmin.mockResolvedValueOnce(true);
+    const implications = [
+      {
+        id: 'impl-1',
+        implyingTagId: 'tag-a',
+        impliedTagId: 'tag-b',
+        createdAt: new Date('2026-01-01'),
+        implyingTag: { id: 'tag-a', name: 'panties', displayName: 'パンツ' },
+        impliedTag: { id: 'tag-b', name: 'clothing', displayName: '衣服' },
+      },
+    ];
+    mockImplicationFindMany.mockResolvedValueOnce(implications);
+    mockImplicationCount.mockResolvedValueOnce(1);
+
+    // When: making GET request
+    const request = new Request('http://localhost/api/admin/tag-implications');
+    const response = await GET(request);
+    const body = await response.json();
+
+    // Then: returns implications with tag info
+    expect(response.status).toBe(200);
+    expect(body.implications).toHaveLength(1);
+    expect(body.implications[0].implyingTag.name).toBe('panties');
+    expect(body.implications[0].impliedTag.name).toBe('clothing');
+    expect(body.total).toBe(1);
+  });
+
+  it('should support pagination with limit and offset', async () => {
+    // Given: admin user
+    mockIsAdmin.mockResolvedValueOnce(true);
+    mockImplicationFindMany.mockResolvedValueOnce([]);
+    mockImplicationCount.mockResolvedValueOnce(50);
+
+    // When: making GET request with pagination
+    const request = new Request(
+      'http://localhost/api/admin/tag-implications?limit=10&offset=20'
+    );
+    const response = await GET(request);
+
+    // Then: pagination params are applied
+    expect(response.status).toBe(200);
+    expect(mockImplicationFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 10,
+        skip: 20,
+      })
+    );
+  });
+
+  it('should filter by tagId when provided', async () => {
+    // Given: admin user
+    mockIsAdmin.mockResolvedValueOnce(true);
+    mockImplicationFindMany.mockResolvedValueOnce([]);
+    mockImplicationCount.mockResolvedValueOnce(0);
+
+    // When: making GET request with tagId filter
+    const request = new Request(
+      'http://localhost/api/admin/tag-implications?tagId=tag-a'
+    );
+    const response = await GET(request);
+
+    // Then: filter is applied
+    expect(response.status).toBe(200);
+    expect(mockImplicationFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            { implyingTagId: 'tag-a' },
+            { impliedTagId: 'tag-a' },
+          ]),
+        }),
+      })
+    );
+  });
+});
+
+describe('POST /api/admin/tag-implications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 403 when user is not admin', async () => {
+    // Given: non-admin user
+    mockIsAdmin.mockResolvedValueOnce(false);
+
+    // When: making POST request
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'POST',
+      body: JSON.stringify({
+        implyingTagId: 'tag-a',
+        impliedTagId: 'tag-b',
+      }),
+    });
+    const response = await POST(request);
+
+    // Then: forbidden
+    expect(response.status).toBe(403);
+  });
+
+  it('should create implication successfully', async () => {
+    // Given: admin user, valid tags, no cycle
+    mockIsAdmin.mockResolvedValueOnce(true);
+    mockTagFindUnique
+      .mockResolvedValueOnce({ id: 'tag-a', name: 'panties' })
+      .mockResolvedValueOnce({ id: 'tag-b', name: 'clothing' });
+    mockWouldCreateCycle.mockResolvedValueOnce(false);
+    mockImplicationFindUnique.mockResolvedValueOnce(null); // no duplicate
+    const created = {
+      id: 'impl-1',
+      implyingTagId: 'tag-a',
+      impliedTagId: 'tag-b',
+      createdAt: new Date(),
+    };
+    mockImplicationCreate.mockResolvedValueOnce(created);
+
+    // When: creating implication
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'POST',
+      body: JSON.stringify({
+        implyingTagId: 'tag-a',
+        impliedTagId: 'tag-b',
+      }),
+    });
+    const response = await POST(request);
+
+    // Then: created successfully
+    expect(response.status).toBe(201);
+  });
+
+  it('should return 400 when implyingTagId is missing', async () => {
+    // Given: admin user, missing implyingTagId
+    mockIsAdmin.mockResolvedValueOnce(true);
+
+    // When: creating implication without implyingTagId
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'POST',
+      body: JSON.stringify({ impliedTagId: 'tag-b' }),
+    });
+    const response = await POST(request);
+
+    // Then: bad request
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 when impliedTagId is missing', async () => {
+    // Given: admin user, missing impliedTagId
+    mockIsAdmin.mockResolvedValueOnce(true);
+
+    // When: creating implication without impliedTagId
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'POST',
+      body: JSON.stringify({ implyingTagId: 'tag-a' }),
+    });
+    const response = await POST(request);
+
+    // Then: bad request
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 for self-referencing implication', async () => {
+    // Given: admin user, same tag for both sides
+    mockIsAdmin.mockResolvedValueOnce(true);
+
+    // When: creating self-referencing implication
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'POST',
+      body: JSON.stringify({
+        implyingTagId: 'tag-a',
+        impliedTagId: 'tag-a',
+      }),
+    });
+    const response = await POST(request);
+
+    // Then: bad request
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 when implyingTag does not exist', async () => {
+    // Given: admin user, implyingTag not found
+    mockIsAdmin.mockResolvedValueOnce(true);
+    mockTagFindUnique.mockResolvedValueOnce(null); // implyingTag not found
+
+    // When: creating implication
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'POST',
+      body: JSON.stringify({
+        implyingTagId: 'nonexistent',
+        impliedTagId: 'tag-b',
+      }),
+    });
+    const response = await POST(request);
+
+    // Then: bad request
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 when impliedTag does not exist', async () => {
+    // Given: admin user, impliedTag not found
+    mockIsAdmin.mockResolvedValueOnce(true);
+    mockTagFindUnique
+      .mockResolvedValueOnce({ id: 'tag-a', name: 'panties' })
+      .mockResolvedValueOnce(null); // impliedTag not found
+
+    // When: creating implication
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'POST',
+      body: JSON.stringify({
+        implyingTagId: 'tag-a',
+        impliedTagId: 'nonexistent',
+      }),
+    });
+    const response = await POST(request);
+
+    // Then: bad request
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 400 when cycle would be created', async () => {
+    // Given: admin user, valid tags, but would create cycle
+    mockIsAdmin.mockResolvedValueOnce(true);
+    mockTagFindUnique
+      .mockResolvedValueOnce({ id: 'tag-a', name: 'panties' })
+      .mockResolvedValueOnce({ id: 'tag-b', name: 'clothing' });
+    mockWouldCreateCycle.mockResolvedValueOnce(true);
+
+    // When: creating implication that would cause cycle
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'POST',
+      body: JSON.stringify({
+        implyingTagId: 'tag-a',
+        impliedTagId: 'tag-b',
+      }),
+    });
+    const response = await POST(request);
+
+    // Then: bad request with cycle error
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toMatch(/循環/);
+  });
+
+  it('should return 409 when duplicate implication exists', async () => {
+    // Given: admin user, valid tags, no cycle, but duplicate exists
+    mockIsAdmin.mockResolvedValueOnce(true);
+    mockTagFindUnique
+      .mockResolvedValueOnce({ id: 'tag-a', name: 'panties' })
+      .mockResolvedValueOnce({ id: 'tag-b', name: 'clothing' });
+    mockWouldCreateCycle.mockResolvedValueOnce(false);
+    mockImplicationFindUnique.mockResolvedValueOnce({
+      id: 'existing-impl',
+    }); // duplicate found
+
+    // When: creating duplicate implication
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'POST',
+      body: JSON.stringify({
+        implyingTagId: 'tag-a',
+        impliedTagId: 'tag-b',
+      }),
+    });
+    const response = await POST(request);
+
+    // Then: conflict
+    expect(response.status).toBe(409);
+  });
+});
+
+describe('DELETE /api/admin/tag-implications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 403 when user is not admin', async () => {
+    // Given: non-admin user
+    mockIsAdmin.mockResolvedValueOnce(false);
+
+    // When: making DELETE request
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'DELETE',
+      body: JSON.stringify({ id: 'impl-1' }),
+    });
+    const response = await DELETE(request);
+
+    // Then: forbidden
+    expect(response.status).toBe(403);
+  });
+
+  it('should delete implication successfully', async () => {
+    // Given: admin user, existing implication
+    mockIsAdmin.mockResolvedValueOnce(true);
+    const deleted = {
+      id: 'impl-1',
+      implyingTagId: 'tag-a',
+      impliedTagId: 'tag-b',
+    };
+    mockImplicationDelete.mockResolvedValueOnce(deleted);
+
+    // When: deleting implication
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'DELETE',
+      body: JSON.stringify({ id: 'impl-1' }),
+    });
+    const response = await DELETE(request);
+
+    // Then: deleted successfully
+    expect(response.status).toBe(200);
+  });
+
+  it('should return 400 when id is missing', async () => {
+    // Given: admin user, no id
+    mockIsAdmin.mockResolvedValueOnce(true);
+
+    // When: deleting without id
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'DELETE',
+      body: JSON.stringify({}),
+    });
+    const response = await DELETE(request);
+
+    // Then: bad request
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 404 when implication does not exist', async () => {
+    // Given: admin user, implication not found
+    mockIsAdmin.mockResolvedValueOnce(true);
+    mockImplicationDelete.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError('Record to delete not found', {
+        code: 'P2025',
+        clientVersion: '1',
+      })
+    );
+
+    // When: deleting nonexistent implication
+    const request = new Request('http://localhost/api/admin/tag-implications', {
+      method: 'DELETE',
+      body: JSON.stringify({ id: 'nonexistent' }),
+    });
+    const response = await DELETE(request);
+
+    // Then: not found
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/api/admin/tag-implications/route.ts
+++ b/src/app/api/admin/tag-implications/route.ts
@@ -96,31 +96,34 @@ export async function POST(request: Request) {
       );
     }
 
-    if (await wouldCreateCycle(implyingTagId, impliedTagId)) {
+    const created = await prisma.$transaction(async (tx) => {
+      if (await wouldCreateCycle(implyingTagId, impliedTagId, tx)) {
+        throw Object.assign(new Error('cycle'), { _appCode: 400, _appMessage: 'この含意を追加すると循環参照が発生します。' });
+      }
+
+      return tx.tagImplication.create({
+        data: { implyingTagId, impliedTagId },
+      });
+    });
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    if (error && typeof error === 'object' && '_appCode' in error) {
+      const appError = error as { _appCode: number; _appMessage: string };
       return NextResponse.json(
-        { message: 'この含意を追加すると循環参照が発生します。' },
-        { status: 400 }
+        { message: appError._appMessage },
+        { status: appError._appCode }
       );
     }
-
-    const existing = await prisma.tagImplication.findUnique({
-      where: {
-        implyingTagId_impliedTagId: { implyingTagId, impliedTagId },
-      },
-    });
-    if (existing) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
       return NextResponse.json(
         { message: 'この含意関係は既に存在します。' },
         { status: 409 }
       );
     }
-
-    const created = await prisma.tagImplication.create({
-      data: { implyingTagId, impliedTagId },
-    });
-
-    return NextResponse.json(created, { status: 201 });
-  } catch (error) {
     console.error('Error creating tag implication:', error);
     return NextResponse.json(
       { message: 'タグ含意の作成に失敗しました。' },

--- a/src/app/api/admin/tag-implications/route.ts
+++ b/src/app/api/admin/tag-implications/route.ts
@@ -1,0 +1,172 @@
+import { NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { isAdmin } from '@/lib/auth';
+import { wouldCreateCycle } from '@/lib/tagImplication';
+
+export async function GET(request: Request) {
+  if (!(await isAdmin())) {
+    return NextResponse.json(
+      { message: '管理者権限が必要です。' },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = parseInt(searchParams.get('limit') ?? '20', 10);
+    const offset = parseInt(searchParams.get('offset') ?? '0', 10);
+    const tagId = searchParams.get('tagId');
+
+    const where = tagId
+      ? { OR: [{ implyingTagId: tagId }, { impliedTagId: tagId }] }
+      : {};
+
+    const [implications, total] = await Promise.all([
+      prisma.tagImplication.findMany({
+        where,
+        include: {
+          implyingTag: {
+            select: { id: true, name: true, displayName: true },
+          },
+          impliedTag: {
+            select: { id: true, name: true, displayName: true },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        skip: offset,
+      }),
+      prisma.tagImplication.count({ where }),
+    ]);
+
+    return NextResponse.json({ implications, total });
+  } catch (error) {
+    console.error('Error fetching tag implications:', error);
+    return NextResponse.json(
+      { message: 'タグ含意の取得に失敗しました。' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  if (!(await isAdmin())) {
+    return NextResponse.json(
+      { message: '管理者権限が必要です。' },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const { implyingTagId, impliedTagId } = body;
+
+    if (!implyingTagId || !impliedTagId) {
+      return NextResponse.json(
+        { message: 'implyingTagId と impliedTagId は必須です。' },
+        { status: 400 }
+      );
+    }
+
+    if (implyingTagId === impliedTagId) {
+      return NextResponse.json(
+        { message: '自己参照の含意は作成できません。' },
+        { status: 400 }
+      );
+    }
+
+    const implyingTag = await prisma.tag.findUnique({
+      where: { id: implyingTagId },
+    });
+    if (!implyingTag) {
+      return NextResponse.json(
+        { message: `タグ '${implyingTagId}' が存在しません。` },
+        { status: 400 }
+      );
+    }
+
+    const impliedTag = await prisma.tag.findUnique({
+      where: { id: impliedTagId },
+    });
+    if (!impliedTag) {
+      return NextResponse.json(
+        { message: `タグ '${impliedTagId}' が存在しません。` },
+        { status: 400 }
+      );
+    }
+
+    if (await wouldCreateCycle(implyingTagId, impliedTagId)) {
+      return NextResponse.json(
+        { message: 'この含意を追加すると循環参照が発生します。' },
+        { status: 400 }
+      );
+    }
+
+    const existing = await prisma.tagImplication.findUnique({
+      where: {
+        implyingTagId_impliedTagId: { implyingTagId, impliedTagId },
+      },
+    });
+    if (existing) {
+      return NextResponse.json(
+        { message: 'この含意関係は既に存在します。' },
+        { status: 409 }
+      );
+    }
+
+    const created = await prisma.tagImplication.create({
+      data: { implyingTagId, impliedTagId },
+    });
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    console.error('Error creating tag implication:', error);
+    return NextResponse.json(
+      { message: 'タグ含意の作成に失敗しました。' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  if (!(await isAdmin())) {
+    return NextResponse.json(
+      { message: '管理者権限が必要です。' },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const { id } = body;
+
+    if (!id) {
+      return NextResponse.json(
+        { message: '削除対象の含意ID (id) が必要です。' },
+        { status: 400 }
+      );
+    }
+
+    const deleted = await prisma.tagImplication.delete({
+      where: { id },
+    });
+
+    return NextResponse.json(deleted);
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2025'
+    ) {
+      return NextResponse.json(
+        { message: '指定された含意IDが見つかりません。' },
+        { status: 404 }
+      );
+    }
+    console.error('Error deleting tag implication:', error);
+    return NextResponse.json(
+      { message: 'タグ含意の削除に失敗しました。' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/products/[productId]/tags/__tests__/route.test.ts
+++ b/src/app/api/products/[productId]/tags/__tests__/route.test.ts
@@ -72,7 +72,10 @@ describe('PUT /api/products/[productId]/tags - implication auto-apply', () => {
       .mockResolvedValueOnce([{ tagId: 'tag-a' }]) // manual tags query
       .mockResolvedValueOnce([{ tagId: 'tag-a' }]); // existing tags query
 
-    mockTagFindUnique.mockResolvedValue({ id: 'tag-a', name: 'panties' });
+    mockTagFindUnique.mockImplementation(({ where }: { where: { name: string } }) => {
+      if (where.name === 'panties') return Promise.resolve({ id: 'tag-a', name: 'panties' });
+      return Promise.resolve(null);
+    });
     mockResolveImplications.mockResolvedValueOnce(['tag-b']);
 
     // When: saving tags
@@ -99,9 +102,11 @@ describe('PUT /api/products/[productId]/tags - implication auto-apply', () => {
       .mockResolvedValueOnce([{ tagId: 'tag-a' }, { tagId: 'tag-b' }]) // manual tags
       .mockResolvedValueOnce([{ tagId: 'tag-a' }, { tagId: 'tag-b' }]); // existing tags
 
-    mockTagFindUnique
-      .mockResolvedValueOnce({ id: 'tag-a', name: 'panties' })
-      .mockResolvedValueOnce({ id: 'tag-b', name: 'clothing' });
+    mockTagFindUnique.mockImplementation(({ where }: { where: { name: string } }) => {
+      if (where.name === 'panties') return Promise.resolve({ id: 'tag-a', name: 'panties' });
+      if (where.name === 'clothing') return Promise.resolve({ id: 'tag-b', name: 'clothing' });
+      return Promise.resolve(null);
+    });
     mockResolveImplications.mockResolvedValueOnce(['tag-b']);
 
     // When: saving tags
@@ -126,9 +131,11 @@ describe('PUT /api/products/[productId]/tags - implication auto-apply', () => {
       .mockResolvedValueOnce([{ tagId: 'tag-a' }, { tagId: 'tag-c' }])
       .mockResolvedValueOnce([{ tagId: 'tag-a' }, { tagId: 'tag-c' }]);
 
-    mockTagFindUnique
-      .mockResolvedValueOnce({ id: 'tag-a', name: 'panties' })
-      .mockResolvedValueOnce({ id: 'tag-c', name: 'underwear' });
+    mockTagFindUnique.mockImplementation(({ where }: { where: { name: string } }) => {
+      if (where.name === 'panties') return Promise.resolve({ id: 'tag-a', name: 'panties' });
+      if (where.name === 'underwear') return Promise.resolve({ id: 'tag-c', name: 'underwear' });
+      return Promise.resolve(null);
+    });
     mockResolveImplications.mockResolvedValueOnce([]);
 
     // When: saving tags

--- a/src/app/api/products/[productId]/tags/__tests__/route.test.ts
+++ b/src/app/api/products/[productId]/tags/__tests__/route.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockAuth = vi.fn();
+vi.mock('@/auth', () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock('@/lib/sanitize', () => ({
+  sanitizeAndValidate: (name: string) => name,
+}));
+
+const mockProductTagFindMany = vi.fn();
+const mockProductTagDeleteMany = vi.fn();
+const mockProductTagCreate = vi.fn();
+const mockTagFindUnique = vi.fn();
+const mockTagCreate = vi.fn();
+const mockTagEditHistoryFindFirst = vi.fn();
+const mockTagEditHistoryCreate = vi.fn();
+
+const mockTx = {
+  productTag: {
+    findMany: (...args: unknown[]) => mockProductTagFindMany(...args),
+    deleteMany: (...args: unknown[]) => mockProductTagDeleteMany(...args),
+    create: (...args: unknown[]) => mockProductTagCreate(...args),
+  },
+  tag: {
+    findUnique: (...args: unknown[]) => mockTagFindUnique(...args),
+    create: (...args: unknown[]) => mockTagCreate(...args),
+  },
+  tagEditHistory: {
+    findFirst: (...args: unknown[]) => mockTagEditHistoryFindFirst(...args),
+    create: (...args: unknown[]) => mockTagEditHistoryCreate(...args),
+  },
+};
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    $transaction: (fn: (tx: typeof mockTx) => Promise<void>) => fn(mockTx),
+  },
+}));
+
+const mockResolveImplications = vi.fn();
+vi.mock('@/lib/tagImplication', () => ({
+  resolveImplications: (...args: unknown[]) => mockResolveImplications(...args),
+}));
+
+const { PUT } = await import('../route');
+
+function createPutRequest(productId: string, tags: { name: string }[], comment?: string) {
+  const req = new NextRequest(`http://localhost/api/products/${productId}/tags`, {
+    method: 'PUT',
+    body: JSON.stringify({ tags, comment }),
+  });
+  return { req, context: { params: Promise.resolve({ productId }) } };
+}
+
+describe('PUT /api/products/[productId]/tags - implication auto-apply', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ user: { id: 'user-1' } });
+    mockProductTagDeleteMany.mockResolvedValue({ count: 0 });
+    mockProductTagCreate.mockResolvedValue({});
+    mockTagEditHistoryFindFirst.mockResolvedValue(null);
+    mockTagEditHistoryCreate.mockResolvedValue({});
+  });
+
+  it('should auto-add implied tags with isImplied: true', async () => {
+    // Given: tag-a exists and implies tag-b
+    mockProductTagFindMany
+      .mockResolvedValueOnce([]) // currentProductTags (initial)
+      .mockResolvedValueOnce([{ tagId: 'tag-a' }]) // manual tags query
+      .mockResolvedValueOnce([{ tagId: 'tag-a' }]); // existing tags query
+
+    mockTagFindUnique.mockResolvedValue({ id: 'tag-a', name: 'panties' });
+    mockResolveImplications.mockResolvedValueOnce(['tag-b']);
+
+    // When: saving tags
+    const { req, context } = createPutRequest('product-1', [{ name: 'panties' }]);
+    const response = await PUT(req, context);
+
+    // Then: implied tag created with isImplied: true
+    expect(response.status).toBe(200);
+    expect(mockProductTagCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          productId: 'product-1',
+          tagId: 'tag-b',
+          isImplied: true,
+        }),
+      })
+    );
+  });
+
+  it('should skip implied tags that already exist as manual tags', async () => {
+    // Given: tag-a implies tag-b, but tag-b is already a manual tag
+    mockProductTagFindMany
+      .mockResolvedValueOnce([]) // currentProductTags
+      .mockResolvedValueOnce([{ tagId: 'tag-a' }, { tagId: 'tag-b' }]) // manual tags
+      .mockResolvedValueOnce([{ tagId: 'tag-a' }, { tagId: 'tag-b' }]); // existing tags
+
+    mockTagFindUnique
+      .mockResolvedValueOnce({ id: 'tag-a', name: 'panties' })
+      .mockResolvedValueOnce({ id: 'tag-b', name: 'clothing' });
+    mockResolveImplications.mockResolvedValueOnce(['tag-b']);
+
+    // When: saving tags
+    const { req, context } = createPutRequest('product-1', [
+      { name: 'panties' },
+      { name: 'clothing' },
+    ]);
+    const response = await PUT(req, context);
+
+    // Then: no duplicate tag-b created
+    expect(response.status).toBe(200);
+    const impliedCreates = mockProductTagCreate.mock.calls.filter(
+      (call) => call[0]?.data?.isImplied === true
+    );
+    expect(impliedCreates).toHaveLength(0);
+  });
+
+  it('should call resolveImplications with manual tag IDs', async () => {
+    // Given: manual tags exist
+    mockProductTagFindMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ tagId: 'tag-a' }, { tagId: 'tag-c' }])
+      .mockResolvedValueOnce([{ tagId: 'tag-a' }, { tagId: 'tag-c' }]);
+
+    mockTagFindUnique
+      .mockResolvedValueOnce({ id: 'tag-a', name: 'panties' })
+      .mockResolvedValueOnce({ id: 'tag-c', name: 'underwear' });
+    mockResolveImplications.mockResolvedValueOnce([]);
+
+    // When: saving tags
+    const { req, context } = createPutRequest('product-1', [
+      { name: 'panties' },
+      { name: 'underwear' },
+    ]);
+    await PUT(req, context);
+
+    // Then: resolveImplications called with manual tag IDs and transaction client
+    expect(mockResolveImplications).toHaveBeenCalledWith(
+      ['tag-a', 'tag-c'],
+      mockTx
+    );
+  });
+});

--- a/src/app/api/products/[productId]/tags/route.ts
+++ b/src/app/api/products/[productId]/tags/route.ts
@@ -42,7 +42,7 @@ export async function PUT(
         include: { tag: true },
       });
 
-      const manualProductTags = currentProductTags.filter(pt => !pt.isOfficial);
+      const manualProductTags = currentProductTags.filter(pt => !pt.isOfficial && !pt.isImplied);
 
       const currentManualTagNames = new Set(
         manualProductTags.map((pt: { tag: { name: string } }) => pt.tag.name)

--- a/src/app/api/products/[productId]/tags/route.ts
+++ b/src/app/api/products/[productId]/tags/route.ts
@@ -1,14 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
-import { auth } from '@/auth'; // authをインポート
+import { auth } from '@/auth';
 import { sanitizeAndValidate } from '@/lib/sanitize';
+import { resolveImplications } from '@/lib/tagImplication';
 
 export async function PUT(
   req: NextRequest,
   context: { params: Promise<{ productId: string }> }
 ) {
-  const session = await auth(); // セッション情報を取得
+  const session = await auth();
 
   if (!session || !session.user || !session.user.id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -36,14 +37,11 @@ export async function PUT(
 
 
     await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
-      // 現在の商品のタグを取得（公式/独自の区分を含む）
       const currentProductTags = await tx.productTag.findMany({
         where: { productId: productId },
         include: { tag: true },
       });
 
-      // 公式タグと独自タグを分離
-      // const officialProductTags = currentProductTags.filter(pt => pt.isOfficial); // Unused
       const manualProductTags = currentProductTags.filter(pt => !pt.isOfficial);
 
       const currentManualTagNames = new Set(
@@ -56,7 +54,6 @@ export async function PUT(
       const removedTags: string[] = [];
       const keptTags: string[] = [];
 
-      // 削除された独自タグを特定
       for (const currentTag of manualProductTags) {
         if (!newTagNames.has(currentTag.tag.name)) {
           removedTags.push(currentTag.tag.id);
@@ -65,10 +62,8 @@ export async function PUT(
         }
       }
 
-      // 追加されたタグを特定
       for (const newTagData of sanitizedTags) {
         if (!currentManualTagNames.has(newTagData.name)) {
-          // 新規タグの場合は、まずTagモデルに存在するか確認し、なければ作成
           let tag = await tx.tag.findUnique({
             where: { name: newTagData.name },
           });
@@ -77,7 +72,7 @@ export async function PUT(
             tag = await tx.tag.create({
               data: {
                 name: newTagData.name,
-                language: 'ja', // デフォルト言語を日本語に設定
+                language: 'ja',
               },
             });
           }
@@ -94,14 +89,12 @@ export async function PUT(
         },
       });
 
-      // 新しい独自タグを作成または既存のタグと関連付け
       for (const tagData of sanitizedTags) {
         let tag = await tx.tag.findUnique({
           where: { name: tagData.name },
         });
 
         if (!tag) {
-          // タグが存在しない場合は新規作成
           tag = await tx.tag.create({
             data: {
               name: tagData.name,
@@ -110,7 +103,6 @@ export async function PUT(
           });
         }
 
-        // ProductTagを作成（独自タグとして: isOfficial: false）
         await tx.productTag.create({
           data: {
             productId: productId,
@@ -121,16 +113,44 @@ export async function PUT(
         });
       }
 
-      // 独自タグ（isOfficial: false）のみを削除したので、公式タグはそのまま残ります。再作成は不要です。
+      const manualTagIds = await tx.productTag
+        .findMany({
+          where: { productId, isOfficial: false, isImplied: false },
+          select: { tagId: true },
+        })
+        .then((pts) => pts.map((pt) => pt.tagId));
 
-      // 最新のバージョン番号を取得
+      const impliedTagIds = await resolveImplications(manualTagIds, tx);
+
+      const existingTagIds = new Set(
+        (
+          await tx.productTag.findMany({
+            where: { productId },
+            select: { tagId: true },
+          })
+        ).map((pt) => pt.tagId)
+      );
+
+      for (const impliedTagId of impliedTagIds) {
+        if (!existingTagIds.has(impliedTagId)) {
+          await tx.productTag.create({
+            data: {
+              productId,
+              tagId: impliedTagId,
+              userId: session.user.id!,
+              isOfficial: false,
+              isImplied: true,
+            },
+          });
+        }
+      }
+
       const latestHistory = await tx.tagEditHistory.findFirst({
         where: { productId: productId },
         orderBy: { version: 'desc' },
       });
       const newVersion = (latestHistory?.version || 0) + 1;
 
-      // TagEditHistoryを作成（独自タグの変更のみを記録）
       await tx.tagEditHistory.create({
         data: {
           productId: productId,

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -19,6 +19,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
     { href: '/admin/avatars', label: '🤖 アバター管理' },
     { href: '/admin/users', label: '👥 ユーザー管理' },
     { href: '/admin/booth-scraper', label: '🔄 BOOTHスクレイパー' },
+    { href: '/admin/tag-implications', label: '🔗 含意タグ管理' },
   ];
 
   const isActive = (href: string, exact?: boolean) => {

--- a/src/components/admin/TagImplicationCreateModal.tsx
+++ b/src/components/admin/TagImplicationCreateModal.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import TagSearchAutocomplete from './TagSearchAutocomplete';
+
+interface Tag {
+  id: string;
+  name: string;
+  displayName: string | null;
+}
+
+interface TagImplicationCreateModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export default function TagImplicationCreateModal({
+  open,
+  onClose,
+  onCreated,
+}: TagImplicationCreateModalProps) {
+  const [implyingTag, setImplyingTag] = useState<Tag | null>(null);
+  const [impliedTag, setImpliedTag] = useState<Tag | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!implyingTag || !impliedTag) {
+      toast.error('元タグと含意タグの両方を選択してください。');
+      return;
+    }
+
+    if (implyingTag.id === impliedTag.id) {
+      toast.error('同じタグは選択できません。');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch('/api/admin/tag-implications', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          implyingTagId: implyingTag.id,
+          impliedTagId: impliedTag.id,
+        }),
+      });
+
+      if (res.ok) {
+        toast.success('含意ルールを作成しました。');
+        setImplyingTag(null);
+        setImpliedTag(null);
+        onCreated();
+        onClose();
+      } else {
+        const data = await res.json();
+        toast.error(data.message || '作成に失敗しました。');
+      }
+    } catch {
+      toast.error('通信エラーが発生しました。');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setImplyingTag(null);
+      setImpliedTag(null);
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>含意ルールを追加</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">元タグ (A)</label>
+            <TagSearchAutocomplete
+              value={implyingTag}
+              onChange={setImplyingTag}
+              placeholder="元タグを検索..."
+            />
+          </div>
+
+          <div className="text-center text-sm text-gray-500 dark:text-gray-400">
+            A が付くと → B も自動付与
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">含意タグ (B)</label>
+            <TagSearchAutocomplete
+              value={impliedTag}
+              onChange={setImpliedTag}
+              placeholder="含意タグを検索..."
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? '作成中...' : '作成'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/TagImplicationManager.tsx
+++ b/src/components/admin/TagImplicationManager.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useDebounce } from '@/hooks/useDebounce';
+import TagImplicationTable from './TagImplicationTable';
+import TagImplicationCreateModal from './TagImplicationCreateModal';
+
+interface Tag {
+  id: string;
+  name: string;
+  displayName: string | null;
+}
+
+interface TagImplication {
+  id: string;
+  implyingTag: Tag;
+  impliedTag: Tag;
+  createdAt: string;
+}
+
+const PAGE_SIZE = 20;
+
+export default function TagImplicationManager() {
+  const [implications, setImplications] = useState<TagImplication[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const debouncedSearch = useDebounce(searchQuery, 300);
+
+  const fetchImplications = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      let tagId: string | null = null;
+
+      if (debouncedSearch.trim()) {
+        const searchRes = await fetch(
+          `/api/tags/search?query=${encodeURIComponent(debouncedSearch)}`
+        );
+        if (searchRes.ok) {
+          const tags = await searchRes.json();
+          if (tags.length > 0) {
+            tagId = tags[0].id;
+          } else {
+            setImplications([]);
+            setTotal(0);
+            setIsLoading(false);
+            return;
+          }
+        }
+      }
+
+      const params = new URLSearchParams({
+        limit: String(PAGE_SIZE),
+        offset: String(page * PAGE_SIZE),
+      });
+      if (tagId) {
+        params.set('tagId', tagId);
+      }
+
+      const res = await fetch(`/api/admin/tag-implications?${params}`);
+      if (res.ok) {
+        const data = await res.json();
+        setImplications(data.implications);
+        setTotal(data.total);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setIsLoading(false);
+    }
+  }, [debouncedSearch, page, refreshKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    fetchImplications();
+  }, [fetchImplications]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearch]);
+
+  const handleRefresh = () => {
+    setRefreshKey((prev) => prev + 1);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xl font-semibold">含意タグ管理</h2>
+        <Button onClick={() => setIsCreateModalOpen(true)}>
+          含意ルールを追加
+        </Button>
+      </div>
+
+      <div className="mb-4">
+        <Input
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="タグ名で検索..."
+          className="max-w-sm"
+        />
+      </div>
+
+      <TagImplicationTable
+        implications={implications}
+        total={total}
+        page={page}
+        onPageChange={setPage}
+        onDeleted={handleRefresh}
+        isLoading={isLoading}
+      />
+
+      <TagImplicationCreateModal
+        open={isCreateModalOpen}
+        onClose={() => setIsCreateModalOpen(false)}
+        onCreated={handleRefresh}
+      />
+    </div>
+  );
+}

--- a/src/components/admin/TagImplicationTable.tsx
+++ b/src/components/admin/TagImplicationTable.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+
+interface Tag {
+  id: string;
+  name: string;
+  displayName: string | null;
+}
+
+interface TagImplication {
+  id: string;
+  implyingTag: Tag;
+  impliedTag: Tag;
+  createdAt: string;
+}
+
+interface TagImplicationTableProps {
+  implications: TagImplication[];
+  total: number;
+  page: number;
+  onPageChange: (page: number) => void;
+  onDeleted: () => void;
+  isLoading: boolean;
+}
+
+const PAGE_SIZE = 20;
+
+export default function TagImplicationTable({
+  implications,
+  total,
+  page,
+  onPageChange,
+  onDeleted,
+  isLoading,
+}: TagImplicationTableProps) {
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id);
+    try {
+      const res = await fetch('/api/admin/tag-implications', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id }),
+      });
+
+      if (res.ok) {
+        toast.success('含意ルールを削除しました。');
+        onDeleted();
+      } else {
+        const data = await res.json();
+        toast.error(data.message || '削除に失敗しました。');
+      }
+    } catch {
+      toast.error('通信エラーが発生しました。');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const formatTagName = (tag: Tag) => tag.displayName || tag.name;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {[...Array(5)].map((_, i) => (
+          <div
+            key={i}
+            className="h-12 bg-gray-100 dark:bg-gray-800 rounded animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (implications.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+        含意ルールがありません
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>元タグ (A)</TableHead>
+            <TableHead className="text-center w-12"></TableHead>
+            <TableHead>含意タグ (B)</TableHead>
+            <TableHead>作成日</TableHead>
+            <TableHead className="text-right">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {implications.map((impl) => (
+            <TableRow key={impl.id}>
+              <TableCell className="font-medium">
+                {formatTagName(impl.implyingTag)}
+              </TableCell>
+              <TableCell className="text-center text-gray-400">→</TableCell>
+              <TableCell className="font-medium">
+                {formatTagName(impl.impliedTag)}
+              </TableCell>
+              <TableCell className="text-gray-500 text-sm">
+                {new Date(impl.createdAt).toLocaleDateString('ja-JP')}
+              </TableCell>
+              <TableCell className="text-right">
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      disabled={deletingId === impl.id}
+                    >
+                      削除
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>含意ルールの削除</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        「{formatTagName(impl.implyingTag)} → {formatTagName(impl.impliedTag)}」
+                        の含意ルールを削除しますか？この操作は取り消せません。
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                      <AlertDialogAction onClick={() => handleDelete(impl.id)}>
+                        削除する
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-4">
+          <p className="text-sm text-gray-500">
+            全 {total} 件中 {page * PAGE_SIZE + 1} - {Math.min((page + 1) * PAGE_SIZE, total)} 件
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(page - 1)}
+              disabled={page === 0}
+            >
+              前へ
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(page + 1)}
+              disabled={page >= totalPages - 1}
+            >
+              次へ
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/TagSearchAutocomplete.tsx
+++ b/src/components/admin/TagSearchAutocomplete.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Input } from '@/components/ui/input';
+import { useDebounce } from '@/hooks/useDebounce';
+
+interface Tag {
+  id: string;
+  name: string;
+  displayName: string | null;
+}
+
+interface TagSearchAutocompleteProps {
+  value: Tag | null;
+  onChange: (tag: Tag | null) => void;
+  placeholder?: string;
+}
+
+export default function TagSearchAutocomplete({
+  value,
+  onChange,
+  placeholder = 'タグを検索...',
+}: TagSearchAutocompleteProps) {
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<Tag[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const [isLoading, setIsLoading] = useState(false);
+  const debouncedQuery = useDebounce(query, 300);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const fetchSuggestions = useCallback(async (q: string) => {
+    if (!q.trim()) {
+      setSuggestions([]);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/tags/search?query=${encodeURIComponent(q)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setSuggestions(data);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSuggestions(debouncedQuery);
+  }, [debouncedQuery, fetchSuggestions]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSelect = (tag: Tag) => {
+    onChange(tag);
+    setQuery('');
+    setSuggestions([]);
+    setIsOpen(false);
+    setHighlightIndex(-1);
+  };
+
+  const handleClear = () => {
+    onChange(null);
+    setQuery('');
+    setSuggestions([]);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen || suggestions.length === 0) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightIndex((prev) => (prev + 1) % suggestions.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightIndex((prev) => (prev - 1 + suggestions.length) % suggestions.length);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (highlightIndex >= 0 && highlightIndex < suggestions.length) {
+        handleSelect(suggestions[highlightIndex]);
+      }
+    } else if (e.key === 'Escape') {
+      setIsOpen(false);
+      setHighlightIndex(-1);
+    }
+  };
+
+  if (value) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 bg-gray-50 dark:bg-gray-800">
+        <span className="text-sm">{value.displayName || value.name}</span>
+        <button
+          type="button"
+          onClick={handleClear}
+          className="ml-auto text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+        >
+          &times;
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Input
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setIsOpen(true);
+          setHighlightIndex(-1);
+        }}
+        onFocus={() => {
+          if (suggestions.length > 0) setIsOpen(true);
+        }}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+      />
+      {isOpen && (query.trim() || isLoading) && (
+        <ul className="absolute z-50 mt-1 w-full max-h-60 overflow-auto rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg">
+          {isLoading && (
+            <li className="px-3 py-2 text-sm text-gray-500">検索中...</li>
+          )}
+          {!isLoading && suggestions.length === 0 && query.trim() && (
+            <li className="px-3 py-2 text-sm text-gray-500">該当するタグがありません</li>
+          )}
+          {suggestions.map((tag, index) => (
+            <li
+              key={tag.id}
+              onClick={() => handleSelect(tag)}
+              onMouseEnter={() => setHighlightIndex(index)}
+              className={`cursor-pointer px-3 py-2 text-sm ${
+                index === highlightIndex
+                  ? 'bg-blue-100 dark:bg-blue-900'
+                  : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+              }`}
+            >
+              {tag.displayName || tag.name}
+              {tag.displayName && (
+                <span className="ml-2 text-xs text-gray-400">({tag.name})</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/tagImplication.test.ts
+++ b/src/lib/__tests__/tagImplication.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFindMany = vi.fn();
+
+vi.mock('../prisma', () => ({
+  prisma: {
+    tagImplication: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+    },
+  },
+}));
+
+// Import after mock setup
+const { resolveImplications, wouldCreateCycle } = await import(
+  '../tagImplication'
+);
+
+describe('resolveImplications', () => {
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  it('should return empty array when no implications exist', async () => {
+    // Given: tags with no implications
+    const tagIds = ['tag-a', 'tag-b'];
+    mockFindMany.mockResolvedValueOnce([]);
+
+    // When: resolving implications
+    const result = await resolveImplications(tagIds);
+
+    // Then: no additional tags
+    expect(result).toEqual([]);
+  });
+
+  it('should return implied tag IDs not already in input', async () => {
+    // Given: tag-a implies tag-c
+    const tagIds = ['tag-a', 'tag-b'];
+    mockFindMany
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-a', impliedTagId: 'tag-c' },
+      ])
+      .mockResolvedValueOnce([]); // tag-c has no further implications
+
+    // When: resolving implications
+    const result = await resolveImplications(tagIds);
+
+    // Then: tag-c is returned as implied
+    expect(result).toEqual(['tag-c']);
+  });
+
+  it('should resolve chained implications (A→B→C)', async () => {
+    // Given: tag-a implies tag-b, tag-b implies tag-c
+    const tagIds = ['tag-a'];
+    mockFindMany
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-a', impliedTagId: 'tag-b' },
+      ])
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-b', impliedTagId: 'tag-c' },
+      ])
+      .mockResolvedValueOnce([]); // tag-c has no further implications
+
+    // When: resolving implications
+    const result = await resolveImplications(tagIds);
+
+    // Then: both tag-b and tag-c are returned
+    expect(result).toContain('tag-b');
+    expect(result).toContain('tag-c');
+    expect(result).toHaveLength(2);
+  });
+
+  it('should not include tags already in input', async () => {
+    // Given: tag-a implies tag-b, but tag-b is already in input
+    const tagIds = ['tag-a', 'tag-b'];
+    mockFindMany
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-a', impliedTagId: 'tag-b' },
+      ])
+      .mockResolvedValueOnce([]); // tag-b checked but no new implications
+
+    // When: resolving implications
+    const result = await resolveImplications(tagIds);
+
+    // Then: tag-b is not duplicated
+    expect(result).toEqual([]);
+  });
+
+  it('should handle circular references without infinite loop', async () => {
+    // Given: tag-a → tag-b → tag-a (circular)
+    const tagIds = ['tag-a'];
+    mockFindMany
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-a', impliedTagId: 'tag-b' },
+      ])
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-b', impliedTagId: 'tag-a' },
+      ]);
+    // BFS stops because tag-a is already visited
+
+    // When: resolving implications
+    const result = await resolveImplications(tagIds);
+
+    // Then: only tag-b is returned, no infinite loop
+    expect(result).toEqual(['tag-b']);
+  });
+
+  it('should handle diamond-shaped implications without duplicates', async () => {
+    // Given: tag-a → tag-b, tag-a → tag-c, both tag-b and tag-c → tag-d
+    const tagIds = ['tag-a'];
+    mockFindMany
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-a', impliedTagId: 'tag-b' },
+        { implyingTagId: 'tag-a', impliedTagId: 'tag-c' },
+      ])
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-b', impliedTagId: 'tag-d' },
+        { implyingTagId: 'tag-c', impliedTagId: 'tag-d' },
+      ])
+      .mockResolvedValueOnce([]); // tag-d has no further implications
+
+    // When: resolving implications
+    const result = await resolveImplications(tagIds);
+
+    // Then: each tag appears only once
+    expect(result).toContain('tag-b');
+    expect(result).toContain('tag-c');
+    expect(result).toContain('tag-d');
+    expect(result).toHaveLength(3);
+  });
+
+  it('should use batch queries with findMany', async () => {
+    // Given: multiple input tags
+    const tagIds = ['tag-a', 'tag-b', 'tag-c'];
+    mockFindMany.mockResolvedValueOnce([]);
+
+    // When: resolving implications
+    await resolveImplications(tagIds);
+
+    // Then: batch query is used with `in` clause
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          implyingTagId: { in: expect.arrayContaining(tagIds) },
+        },
+      })
+    );
+  });
+
+  it('should return empty array for empty input', async () => {
+    // Given: no tags
+    const tagIds: string[] = [];
+
+    // When: resolving implications
+    const result = await resolveImplications(tagIds);
+
+    // Then: empty result, no DB queries
+    expect(result).toEqual([]);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('should stop at MAX_DEPTH to prevent excessive chain traversal', async () => {
+    // Given: a chain deeper than MAX_DEPTH (10 levels)
+    const tagIds = ['tag-0'];
+    for (let i = 0; i < 12; i++) {
+      mockFindMany.mockResolvedValueOnce([
+        { implyingTagId: `tag-${i}`, impliedTagId: `tag-${i + 1}` },
+      ]);
+    }
+
+    // When: resolving implications
+    const result = await resolveImplications(tagIds);
+
+    // Then: should not exceed MAX_DEPTH iterations
+    // findMany should be called at most MAX_DEPTH + 1 times (initial + MAX_DEPTH levels)
+    expect(mockFindMany.mock.calls.length).toBeLessThanOrEqual(11);
+    // Should still return some results (up to depth limit)
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+
+  it('should handle multiple implications from a single tag', async () => {
+    // Given: tag-a implies tag-b, tag-c, tag-d
+    const tagIds = ['tag-a'];
+    mockFindMany
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-a', impliedTagId: 'tag-b' },
+        { implyingTagId: 'tag-a', impliedTagId: 'tag-c' },
+        { implyingTagId: 'tag-a', impliedTagId: 'tag-d' },
+      ])
+      .mockResolvedValueOnce([]); // none of them have further implications
+
+    // When: resolving implications
+    const result = await resolveImplications(tagIds);
+
+    // Then: all three tags are returned
+    expect(result).toContain('tag-b');
+    expect(result).toContain('tag-c');
+    expect(result).toContain('tag-d');
+    expect(result).toHaveLength(3);
+  });
+});
+
+describe('wouldCreateCycle', () => {
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  it('should return true when adding implication would create a direct cycle', async () => {
+    // Given: tag-b already implies tag-a
+    // Adding tag-a → tag-b would create A→B→A cycle
+    mockFindMany
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-b', impliedTagId: 'tag-a' },
+      ]);
+
+    // When: checking if tag-a → tag-b would create a cycle
+    const result = await wouldCreateCycle('tag-a', 'tag-b');
+
+    // Then: cycle detected
+    expect(result).toBe(true);
+  });
+
+  it('should return true when adding implication would create an indirect cycle', async () => {
+    // Given: tag-b → tag-c → tag-a (existing chain)
+    // Adding tag-a → tag-b would create A→B→C→A cycle
+    mockFindMany
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-b', impliedTagId: 'tag-c' },
+      ])
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-c', impliedTagId: 'tag-a' },
+      ]);
+
+    // When: checking if tag-a → tag-b would create a cycle
+    const result = await wouldCreateCycle('tag-a', 'tag-b');
+
+    // Then: cycle detected
+    expect(result).toBe(true);
+  });
+
+  it('should return false when no cycle would be created', async () => {
+    // Given: tag-b has no implications that lead back to tag-a
+    mockFindMany
+      .mockResolvedValueOnce([
+        { implyingTagId: 'tag-b', impliedTagId: 'tag-c' },
+      ])
+      .mockResolvedValueOnce([]); // tag-c has no implications
+
+    // When: checking if tag-a → tag-b would create a cycle
+    const result = await wouldCreateCycle('tag-a', 'tag-b');
+
+    // Then: no cycle
+    expect(result).toBe(false);
+  });
+
+  it('should return false when implied tag has no outgoing implications', async () => {
+    // Given: tag-b has no implications at all
+    mockFindMany.mockResolvedValueOnce([]);
+
+    // When: checking if tag-a → tag-b would create a cycle
+    const result = await wouldCreateCycle('tag-a', 'tag-b');
+
+    // Then: no cycle
+    expect(result).toBe(false);
+  });
+
+  it('should return true for self-reference (A→A)', async () => {
+    // Given/When: checking if tag-a → tag-a would create a cycle
+    const result = await wouldCreateCycle('tag-a', 'tag-a');
+
+    // Then: self-reference is a cycle
+    expect(result).toBe(true);
+  });
+});

--- a/src/lib/tagImplication.ts
+++ b/src/lib/tagImplication.ts
@@ -7,6 +7,10 @@ type DbClient = Prisma.TransactionClient | typeof prisma;
 
 /**
  * BFS で含意チェーンを辿り、入力タグIDに含まれない含意タグIDを返す。
+ *
+ * MAX_DEPTH（現在 10）に達した場合、探索を打ち切り警告をログ出力する。
+ * visitedセットにより無限ループは防止されるが、MAX_DEPTHは異常に深いチェーンへの
+ * パフォーマンス保護として機能する。
  */
 export async function resolveImplications(
   tagIds: string[],
@@ -40,6 +44,12 @@ export async function resolveImplications(
     }
 
     currentBatch = nextBatch;
+
+    if (depth === MAX_DEPTH - 1 && currentBatch.length > 0) {
+      console.warn(
+        `resolveImplications: MAX_DEPTH (${MAX_DEPTH}) に到達しました。含意チェーンが異常に深い可能性があります。入力タグ: [${tagIds.join(', ')}]`
+      );
+    }
   }
 
   return implied;
@@ -47,6 +57,9 @@ export async function resolveImplications(
 
 /**
  * implyingTagId → impliedTagId の含意を追加したとき循環が生じるか BFS で判定する。
+ *
+ * MAX_DEPTH（現在 10）に達した場合、探索を打ち切り警告をログ出力する。
+ * 安全側に倒すため、打ち切り時は false を返す（循環なしとみなす）。
  */
 export async function wouldCreateCycle(
   implyingTagId: string,
@@ -82,6 +95,12 @@ export async function wouldCreateCycle(
     }
 
     currentBatch = nextBatch;
+
+    if (depth === MAX_DEPTH - 1 && currentBatch.length > 0) {
+      console.warn(
+        `wouldCreateCycle: MAX_DEPTH (${MAX_DEPTH}) に到達しました。含意チェーンが異常に深い可能性があります。implyingTagId: ${implyingTagId}, impliedTagId: ${impliedTagId}`
+      );
+    }
   }
 
   return false;

--- a/src/lib/tagImplication.ts
+++ b/src/lib/tagImplication.ts
@@ -1,0 +1,88 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from './prisma';
+
+const MAX_DEPTH = 10;
+
+type DbClient = Prisma.TransactionClient | typeof prisma;
+
+/**
+ * BFS で含意チェーンを辿り、入力タグIDに含まれない含意タグIDを返す。
+ */
+export async function resolveImplications(
+  tagIds: string[],
+  tx?: Prisma.TransactionClient
+): Promise<string[]> {
+  if (tagIds.length === 0) {
+    return [];
+  }
+
+  const db: DbClient = tx ?? prisma;
+  const visited = new Set<string>(tagIds);
+  const implied: string[] = [];
+  let currentBatch = [...tagIds];
+
+  for (let depth = 0; depth < MAX_DEPTH; depth++) {
+    if (currentBatch.length === 0) break;
+
+    const implications = await db.tagImplication.findMany({
+      where: {
+        implyingTagId: { in: currentBatch },
+      },
+    });
+
+    const nextBatch: string[] = [];
+    for (const impl of implications) {
+      if (!visited.has(impl.impliedTagId)) {
+        visited.add(impl.impliedTagId);
+        implied.push(impl.impliedTagId);
+        nextBatch.push(impl.impliedTagId);
+      }
+    }
+
+    currentBatch = nextBatch;
+  }
+
+  return implied;
+}
+
+/**
+ * implyingTagId → impliedTagId の含意を追加したとき循環が生じるか BFS で判定する。
+ */
+export async function wouldCreateCycle(
+  implyingTagId: string,
+  impliedTagId: string,
+  tx?: Prisma.TransactionClient
+): Promise<boolean> {
+  if (implyingTagId === impliedTagId) {
+    return true;
+  }
+
+  const db: DbClient = tx ?? prisma;
+  const visited = new Set<string>([impliedTagId]);
+  let currentBatch = [impliedTagId];
+
+  for (let depth = 0; depth < MAX_DEPTH; depth++) {
+    if (currentBatch.length === 0) break;
+
+    const implications = await db.tagImplication.findMany({
+      where: {
+        implyingTagId: { in: currentBatch },
+      },
+    });
+
+    const nextBatch: string[] = [];
+    for (const impl of implications) {
+      if (impl.impliedTagId === implyingTagId) {
+        return true;
+      }
+      if (!visited.has(impl.impliedTagId)) {
+        visited.add(impl.impliedTagId);
+        nextBatch.push(impl.impliedTagId);
+      }
+    }
+
+    currentBatch = nextBatch;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- タグimplication（含意関係）の管理用CRUD APIを実装
- 循環参照検出ユーティリティを追加
- 重複チェック機能を追加
- 商品タグ付けAPI にimplication自動適用を実装
- テストを追加

## Test plan
- [ ] 管理用tag-implications APIのCRUD操作が正しく動作することを確認
- [ ] 循環参照が正しく検出・拒否されることを確認
- [ ] 商品タグ付け時にimplicationが自動適用されることを確認
- [ ] テストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * タグ含意管理UIを追加（管理メニュー項目、一覧、検索、ページング、作成モーダル、削除）。
  * 管理用のタグ含意API（取得・作成・削除）を追加。

* **改善**
  * 製品タグ編集で含意タグを自動適用・同期するよう強化。
  * 含意解決に深さ制限・循環検出・重複防止を導入し、挙動を堅牢化。

* **テスト**
  * 管理API、含意解決ロジック、製品タグ更新の包括的なテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->